### PR TITLE
fix: owner and foundation same address for reward

### DIFF
--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -466,7 +466,12 @@ func GetRewardBalancesRate(foundationWalletAddr common.Address, statedb *state.S
 
 	foundationReward := new(big.Int).Mul(totalReward, new(big.Int).SetInt64(common.RewardFoundationPercent))
 	foundationReward = new(big.Int).Div(foundationReward, new(big.Int).SetInt64(100))
-	balances[foundationWalletAddr] = foundationReward
+
+	if balances[foundationWalletAddr] != nil {
+		balances[foundationWalletAddr].Add(balances[foundationWalletAddr], foundationReward)
+	} else {
+		balances[foundationWalletAddr] = foundationReward
+	}
 
 	jsonHolders, err := json.Marshal(balances)
 	if err != nil {


### PR DESCRIPTION
# Proposed changes
If foundation is validator owner, then reward will get override. It won't get full 100% of reward but only 10% 

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
