### PR TITLE
fix: getrewardbyaccount api edge case

### DIFF
--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -468,7 +468,7 @@ func (api *API) getRewardFileNamesInRange(begin, end *rpc.BlockNumber) ([]reward
 	startIndex := sort.SearchInts(epochNumbers, int(beginHeader.Number.Int64()))
 	endIndex := sort.SearchInts(epochNumbers, int(endHeader.Number.Int64()))
 	if endIndex == len(epochNumbers) {
-		endIndex = endIndex - 1  //this is to prevent endIndex out of bounds when endInput is higher than last reward(epoch) block but lower than latest block
+		endIndex--  //this is to prevent endIndex out of bounds when endInput is higher than last reward(epoch) block but lower than latest block
 	}
 
 	var rewardfileNamesInRange []rewardFileName


### PR DESCRIPTION
# Proposed changes
Fix "method handler crashed" error when endBlock input is close to current block.
This is because endBlock input is higher than last reward block causing index out of bounds in the reward array.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
