### PR TITLE
feate(core, trie): add UpdateContractCode to the Trie interface #27476

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -93,6 +93,10 @@ type Trie interface {
 	// in the trie with provided address.
 	UpdateAccount(address common.Address, account *types.StateAccount) error
 
+	// UpdateContractCode abstracts code write to the trie. It is expected
+	// to be moved to the stateWriter interface when the latter is ready.
+	UpdateContractCode(address common.Address, codeHash common.Hash, code []byte) error
+
 	// DeleteStorage removes any existing value for key from the trie. If a node
 	// was not found in the database, a trie.MissingNodeError is returned.
 	DeleteStorage(addr common.Address, key []byte) error

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -918,6 +918,7 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 		if obj := s.stateObjects[addr]; !obj.deleted {
 			// Write any contract code associated with the state object
 			if obj.code != nil && obj.dirtyCode {
+				s.trie.UpdateContractCode(obj.Address(), common.BytesToHash(obj.CodeHash()), obj.code)
 				rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)
 				obj.dirtyCode = false
 			}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -176,6 +176,10 @@ func (t *StateTrie) UpdateAccount(address common.Address, acc *types.StateAccoun
 	return nil
 }
 
+func (t *StateTrie) UpdateContractCode(_ common.Address, _ common.Hash, _ []byte) error {
+	return nil
+}
+
 // MustDelete removes any existing value for key from the trie. This function
 // will omit any encountered error but just print out an error message.
 func (t *StateTrie) MustDelete(key []byte) {


### PR DESCRIPTION
# Proposed changes

This pull request introduces a new hook UpdateContractCode to the core/state.Trie interface in the XDC network codebase, enabling trie implementations to be notified when contract bytecode is persisted. Key changes include:

- Interface Extension‌:
  - Adds UpdateContractCode(address, codeHash, code) error to core/state.Trie.
- Integration with State Commit‌:
  - Invokes Trie.UpdateContractCode during StateDB.Commit when a state object has dirty contract code.
- Implementation Details‌:
  - A no-op implementation is provided for trie.StateTrie (MPT-based), as contract code is stored separately via rawdb.WriteCode.
  - Code comments clarify that the hook is an optional extension for trie backends and does not guarantee code persistence in - all implementations.

The PR aligns with Ethereum reference #27476 and focuses on enhancing trie flexibility for contract code management.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
