### PR TITLE
fix(core, trie): revert error removal in (*state.Trie).Commit #27544

### DIFF
--- a/XDCx/tradingstate/XDCx_trie.go
+++ b/XDCx/tradingstate/XDCx_trie.go
@@ -165,7 +165,10 @@ func (t *XDCXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
 	// PR #1103 causes TestRevertStates and TestDumpState to fail,
 	// but we will not fix them since XDCx has been abandoned.
 	// TODO(daniel): The following code may be incorrect, ref PR #25320:
-	root, nodes := t.trie.Commit(false)
+	root, nodes, err := t.trie.Commit(false)
+	if err != nil {
+		return common.Hash{}, err
+	}
 	if nodes != nil {
 		if err := t.trie.UpdateDb(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes)); err != nil {
 			return common.Hash{}, err

--- a/XDCxlending/lendingstate/XDCx_trie.go
+++ b/XDCxlending/lendingstate/XDCx_trie.go
@@ -161,7 +161,10 @@ func (t *XDCXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
 	// PR #1103 causes TestRevertStates and TestDumpState to fail,
 	// but we will not fix them since XDCx has been abandoned.
 	// TODO(daniel): The following code may be incorrect, ref PR #25320:
-	root, nodes := t.trie.Commit(false)
+	root, nodes, err := t.trie.Commit(false)
+	if err != nil {
+		return common.Hash{}, err
+	}
 	if nodes != nil {
 		if err := t.trie.UpdateDb(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes)); err != nil {
 			return common.Hash{}, err

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -110,7 +110,7 @@ type Trie interface {
 	// The returned nodeset can be nil if the trie is clean(nothing to commit).
 	// Once the trie is committed, it's not usable anymore. A new trie must
 	// be created with new root and updated trie database for following usage
-	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet)
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
 
 	// NodeIterator returns an iterator that returns nodes of the trie. Iteration
 	// starts at the key after the given start key. An error will be returned

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -306,7 +306,10 @@ func (s *stateObject) commitTrie() (*trienode.NodeSet, error) {
 	}
 	// Track the amount of time wasted on committing the storage trie
 	defer func(start time.Time) { s.db.StorageCommits += time.Since(start) }(time.Now())
-	root, nodes := tr.Commit(false)
+	root, nodes, err := tr.Commit(false)
+	if err != nil {
+		return nil, err
+	}
 	s.data.Root = root
 	return nodes, nil
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -953,7 +953,10 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 	}
 	// Write the account trie changes, measuring the amount of wasted time
 	start := time.Now()
-	root, set := s.trie.Commit(true)
+	root, set, err := s.trie.Commit(true)
+	if err != nil {
+		return common.Hash{}, err
+	}
 	// Merge the dirty nodes of account trie into global set
 	if set != nil {
 		if err := nodes.Merge(set); err != nil {

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -62,7 +62,7 @@ func TestIterator(t *testing.T) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -254,7 +254,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA := triea.Commit(false)
+	rootA, nodesA, _ := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -263,7 +263,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB := trieb.Commit(false)
+	rootB, nodesB, _ := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -296,7 +296,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA := triea.Commit(false)
+	rootA, nodesA, _ := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -305,7 +305,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB := trieb.Commit(false)
+	rootB, nodesB, _ := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -367,7 +367,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool, scheme string) {
 	for _, val := range testdata1 {
 		tr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := tr.Commit(false)
+	root, nodes, _ := tr.Commit(false)
 	tdb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 	if !memonly {
 		tdb.Commit(root, false)
@@ -477,7 +477,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool, scheme strin
 	for _, val := range testdata1 {
 		ctr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := ctr.Commit(false)
+	root, nodes, _ := ctr.Commit(false)
 	for path, n := range nodes.Nodes {
 		if n.Hash == barNodeHash {
 			barNodePath = []byte(path)
@@ -600,7 +600,7 @@ func makeLargeTestTrie() (*Database, *StateTrie, *loggingDb) {
 		val = crypto.Keccak256(val)
 		trie.MustUpdate(key, val)
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 	triedb.Commit(root, false)
 
@@ -643,7 +643,7 @@ func testIteratorNodeBlob(t *testing.T, scheme string) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 	triedb.Commit(root, false)
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -219,7 +219,7 @@ func (t *StateTrie) GetKey(shaKey []byte) []byte {
 // All cached preimages will be also flushed if preimages recording is enabled.
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
+func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		if t.preimages != nil {

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -60,7 +60,7 @@ func makeTestStateTrie() (*Database, *StateTrie, map[string][]byte) {
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -56,7 +56,7 @@ func makeTestTrie(scheme string) (ethdb.Database, *Database, *StateTrie, map[str
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}
@@ -739,7 +739,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate(key, val)
 		diff[string(key)] = val
 	}
-	root, nodes := srcTrie.Commit(false)
+	root, nodes, _ := srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, 0, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(err)
 	}
@@ -764,7 +764,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate([]byte(k), val)
 		reverted[k] = val
 	}
-	root, nodes = srcTrie.Commit(false)
+	root, nodes, _ = srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, 0, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(err)
 	}

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -70,7 +70,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	}
 	insertSet := copySet(trie.tracer.inserts) // copy before commit
 	deleteSet := copySet(trie.tracer.deletes) // copy before commit
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 
 	seen := setKeys(iterNodes(db, root))
@@ -136,7 +136,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -151,7 +151,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -169,7 +169,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		keys = append(keys, string(key))
 		trie.MustUpdate(key, randBytes(32))
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -184,7 +184,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, key := range keys {
 		trie.MustUpdate([]byte(key), nil)
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -199,7 +199,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), nil)
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -218,7 +218,7 @@ func TestAccessListLeak(t *testing.T) {
 	for _, val := range standard {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 
 	var cases = []struct {
@@ -268,7 +268,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, set := trie.Commit(false)
+	root, set, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(set))
 
 	parent := root
@@ -277,7 +277,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, set = trie.Commit(false)
+	root, set, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(set))
 
 	trie, _ = New(TrieID(root), db)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -802,7 +802,7 @@ func (t *Trie) Hash() common.Hash {
 // The returned nodeset can be nil if the trie is clean (nothing to commit).
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
+func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
 	defer t.tracer.reset()
 	defer func() {
 		t.committed = true
@@ -814,7 +814,7 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 	// - The trie was empty and no update happens
 	// - The trie was non-empty and all nodes are dropped
 	if t.root == nil {
-		return types.EmptyRootHash, nodes
+		return types.EmptyRootHash, nodes, nil
 	}
 	// Derive the hash for all dirty nodes first. We hold the assumption
 	// in the following procedure that all nodes are hashed.
@@ -826,10 +826,10 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 		// Replace the root node with the origin hash in order to
 		// ensure all resolved nodes are dropped after the commit.
 		t.root = hashedNode
-		return rootHash, nil
+		return rootHash, nil, nil
 	}
 	t.root = newCommitter(nodes, t.tracer, collectLeaf).Commit(t.root)
-	return rootHash, nodes
+	return rootHash, nodes, nil
 }
 
 // hashRoot calculates the root hash of the given trie

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -89,7 +89,7 @@ func testMissingNode(t *testing.T, memonly bool, scheme string) {
 	trie := NewEmpty(triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 
 	if !memonly {
@@ -178,7 +178,7 @@ func TestInsert(t *testing.T) {
 	updateString(trie, "A", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	exp = common.HexToHash("d23786fb4a010da3ce639d66d5e904a11dbc02746d1ce25029e53290cabf28ab")
-	root, _ = trie.Commit(false)
+	root, _, _ = trie.Commit(false)
 	if root != exp {
 		t.Errorf("case 2: exp %x got %x", exp, root)
 	}
@@ -203,7 +203,7 @@ func TestGet(t *testing.T) {
 		if i == 1 {
 			return
 		}
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 		trie, _ = New(TrieID(root), db)
 	}
@@ -275,7 +275,7 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals {
 		updateString(trie, val.k, val.v)
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 
 	// create a new trie on top of the database and check that lookups work.
@@ -288,7 +288,7 @@ func TestReplication(t *testing.T) {
 			t.Errorf("trie2 doesn't have %q => %q", kv.k, kv.v)
 		}
 	}
-	hash, nodes := trie2.Commit(false)
+	hash, nodes, _ := trie2.Commit(false)
 	if hash != root {
 		t.Errorf("root failure. expected %x got %x", root, hash)
 	}
@@ -520,7 +520,7 @@ func runRandTest(rt randTest) error {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			root, nodes := tr.Commit(true)
+			root, nodes, _ := tr.Commit(true)
 			if nodes != nil {
 				triedb.Update(root, origin, 0, trienode.NewWithNodeSet(nodes))
 			}
@@ -753,7 +753,7 @@ func TestCommitAfterHash(t *testing.T) {
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
-	root, _ = trie.Commit(false)
+	root, _, _ = trie.Commit(false)
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
@@ -855,7 +855,7 @@ func TestCommitSequence(t *testing.T) {
 			trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 		}
 		// Flush trie -> database
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -896,7 +896,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 			trie.MustUpdate(key, val)
 		}
 		// Flush trie -> database
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -935,7 +935,7 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 			stTrie.Update(key, val)
 		}
 		// Flush trie -> database
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		// Flush memdb -> disk (sponge)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 		db.Commit(root, false)
@@ -983,7 +983,7 @@ func TestCommitSequenceSmallRoot(t *testing.T) {
 	trie.Update(key, []byte{0x1})
 	stTrie.Update(key, []byte{0x1})
 	// Flush trie -> database
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	// Flush memdb -> disk (sponge)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 	db.Commit(root, false)
@@ -1155,7 +1155,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 		trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	h := trie.Hash()
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes))
 	b.StartTimer()
 	triedb.Dereference(h)


### PR DESCRIPTION
# Proposed changes

This pull request addresses an issue related to error handling in the Commit method of the state.Trie component within the XDC network codebase. Key changes include:

Error Handling Reversion‌:  reverts a previous removal of error handling in (*state.Trie).Commit, ensuring errors are properly propagated and managed during state trie commit operations.

The PR focuses on maintaining code reliability and aligning with upstream Ethereum #27544.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
