### PR TITLE
cmd, node, p2p: implement whitelist and blacklist for peers

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -61,6 +61,8 @@ var (
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,
+		utils.PeersWhitelistFlag,
+		utils.PeersBlacklistFlag,
 		utils.BootnodesFlag,
 		utils.BootnodesV4Flag,
 		utils.BootnodesV5Flag,

--- a/node/api.go
+++ b/node/api.go
@@ -65,6 +65,18 @@ func (api *adminAPI) AddPeer(url string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("invalid enode: %v", err)
 	}
+	// only accept the node which is in peer whitelist if the list is not empty
+	if len(server.WhitePeers) > 0 {
+		if _, ok := server.WhitePeers[node.ID]; !ok {
+			return false, fmt.Errorf("peer is not in whitelist: %v, ID: %s", url, node.ID)
+		}
+	}
+	// reject the node which is in peer blacklist
+	if len(server.BlackPeers) > 0 {
+		if _, ok := server.BlackPeers[node.ID]; ok {
+			return false, fmt.Errorf("peer is in blacklist: %v, ID: %s", url, node.ID)
+		}
+	}
 	server.AddPeer(node)
 	return true, nil
 }
@@ -95,6 +107,18 @@ func (api *adminAPI) AddTrustedPeer(url string) (bool, error) {
 	node, err := discover.ParseNode(url)
 	if err != nil {
 		return false, fmt.Errorf("invalid enode: %v", err)
+	}
+	// only accept the node which is in peer whitelist if the list is not empty
+	if len(server.WhitePeers) > 0 {
+		if _, ok := server.WhitePeers[node.ID]; !ok {
+			return false, fmt.Errorf("trusted peer is not in whitelist: %v, ID: %s", url, node.ID)
+		}
+	}
+	// reject the node which is in peer blacklist
+	if len(server.BlackPeers) > 0 {
+		if _, ok := server.BlackPeers[node.ID]; ok {
+			return false, fmt.Errorf("trusted peer is in blacklist: %v, ID: %s", url, node.ID)
+		}
 	}
 	server.AddTrustedPeer(node)
 	return true, nil

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -72,7 +72,9 @@ const (
 	DiscSelf
 	DiscReadTimeout
 	DiscPairPeerStop
-	DiscSubprotocolError = 0x10
+	DiscNonWhitelistedPeer
+	DiscBlacklistedPeer
+	DiscSubprotocolError = DiscReason(0x10)
 )
 
 var discReasonToString = [...]string{
@@ -89,11 +91,13 @@ var discReasonToString = [...]string{
 	DiscSelf:                "connected to self",
 	DiscReadTimeout:         "read timeout",
 	DiscPairPeerStop:        "pair peer connection stop",
+	DiscNonWhitelistedPeer:  "disconnect non-whitelisted peer",
+	DiscBlacklistedPeer:     "disconnect blacklisted peer",
 	DiscSubprotocolError:    "subprotocol error",
 }
 
 func (d DiscReason) String() string {
-	if len(discReasonToString) <= int(d) || int(d) < 0 {
+	if len(discReasonToString) <= int(d) || int(d) < 0 || discReasonToString[int(d)] == "" {
 		return fmt.Sprintf("unknown disconnect reason %d", d)
 	}
 	return discReasonToString[int(d)]
@@ -107,7 +111,7 @@ func discReasonForError(err error) DiscReason {
 	if reason, ok := err.(DiscReason); ok {
 		return reason
 	}
-	if err == errProtocolReturned {
+	if errors.Is(err, errProtocolReturned) {
 		return DiscQuitting
 	}
 	peerError, ok := err.(*peerError)


### PR DESCRIPTION
# Proposed changes

This PR implements the whitelist and blacklist for peers. It:

- initialize the lists by the flags `peers-whitelist` and `peers-blacklist` when start node, but these two can't be used at the same time
- reject the peer when call `admin_addPeer` or `admin_addTrustedPeer`
  - if whitelist is not empty and it is not in whitelist 
  - if it is in blacklist
- reject the peer during setup network connection
  - if whitelist is not empty and it is not in whitelist 
  - if it is in blacklist

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
