### PR TITLE
engine_v2: fix negative underflow in getBlockInfoByEpochNum

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/utils.go
+++ b/consensus/XDPoS/engines/engine_v2/utils.go
@@ -271,7 +271,13 @@ func (x *XDPoS_v2) binarySearchBlockByEpochNumber(chain consensus.ChainReader, t
 			} else {
 				end = header.Number.Uint64()
 				// trick to shorten the search
-				estStart := end - uint64(round)%x.config.Epoch
+				estStart := uint64(0)
+				// if statement to avoid negative underflow
+				roundModEpoch := uint64(round) % x.config.Epoch
+				if end >= roundModEpoch {
+					estStart = end - roundModEpoch
+				}
+
 				if start < estStart {
 					start = estStart
 				}


### PR DESCRIPTION
# Proposed changes
fix: in getBlockInfoByEpochNum, fix negative underflow

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [x] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
