### PR TITLE
build: fix BAD BLOCK error for consensus v1 and Go v1.24 v1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.25-alpine AS builder
 
+ENV GODEBUG=randseednop=0
+
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 ADD . /XDPoSChain

--- a/Dockerfile.bootnode
+++ b/Dockerfile.bootnode
@@ -1,5 +1,7 @@
 FROM golang:1.25-alpine AS builder
 
+ENV GODEBUG=randseednop=0
+
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
 ADD . /XDPoSChain

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,5 +1,7 @@
 FROM golang:1.25-alpine AS builder
 
+ENV GODEBUG=randseednop=0
+
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 ADD . /XDPoSChain

--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.25-alpine AS builder
 
+ENV GODEBUG=randseednop=0
+
 RUN apk add make build-base linux-headers
 
 COPY . /builder


### PR DESCRIPTION
# Proposed changes

Go was upgraded to v1.25.1 in the PR #1476. But consensus v1 does not work because of rand.Seed is a no-op from Go v1.24. So this PR restores the previous behavior of rand.Seed to fix BAD BLOCK error for consensus v1 and Go v1.24 and v1.25.

Ref: 

- https://go.dev/doc/godebug#go-124
- https://pkg.go.dev/math/rand#Seed

```text
Seed uses the provided seed value to initialize the default Source to a deterministic state. Seed values that have the same remainder when divided by 2³¹-1 generate the same pseudo-random sequence. Seed, unlike the [Rand.Seed](https://pkg.go.dev/math/rand#Rand.Seed) method, is safe for concurrent use.

If Seed is not called, the generator is seeded randomly at program startup.

Prior to Go 1.20, the generator was seeded like Seed(1) at program startup. To force the old behavior, call Seed(1) at program startup. Alternately, set GODEBUG=randautoseed=0 in the environment before making any calls to functions in this package.

Deprecated: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator.

As of Go 1.24 [Seed](https://pkg.go.dev/math/rand#Seed) is a no-op. To restore the previous behavior set GODEBUG=randseednop=0.
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
