### PR TITLE
fix: XDPoS_v2 save reward file during Seal for block miner

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -415,7 +415,7 @@ func (x *XDPoS_v2) Finalize(chain consensus.ChainReader, header *types.Header, s
 		x.latestReward, err = deepCloneJSON(rewards)
 		x.lock.Unlock()
 		if err != nil {
-			log.Error("[Finalize] Error deep cloning latest reward", "err", err)
+			log.Error("[Finalize] Error deep cloning latest reward", "err", err, "rewards", rewards)
 			return nil, err
 		}
 
@@ -428,7 +428,7 @@ func (x *XDPoS_v2) Finalize(chain consensus.ChainReader, header *types.Header, s
 		parentHeader := chain.GetHeaderByHash(header.ParentHash)
 		isMyTurn, err := x.yourturn(chain, decodedExtraField.Round, parentHeader, signer)
 		if err != nil {
-			log.Error("[Finalize] Error checking myturn", "err", err)
+			log.Error("[Finalize] Error checking myturn", "err", err, "round", decodedExtraField.Round, "signer", signer, "parentHeader", parentHeader)
 			return nil, err
 		}
 
@@ -505,7 +505,8 @@ func (x *XDPoS_v2) Seal(chain consensus.ChainReader, block *types.Block, stop <-
 		isMyTurn, err := x.yourturn(chain, decodedExtraField.Round, parentHeader, signer)
 
 		if err != nil {
-			log.Error("[Seal] Error checking myturn", "err", err)
+			log.Error("[Seal] Error checking myturn", "err", err, "round", decodedExtraField.Round, "signer", signer, "parentHeader", parentHeader)
+			return nil, err
 		}
 		if isMyTurn { // if not myturn use Finalize to save file
 			x.saveRewardToFile(header.Hash(), header.Number.Uint64())
@@ -1081,7 +1082,7 @@ func (x *XDPoS_v2) saveRewardToFile(blockHash common.Hash, blockNumber uint64) {
 
 	data, err := json.Marshal(rewards)
 	if err != nil {
-		log.Error("[saveRewardToFile] Error Marshalling rewards", "err", err)
+		log.Error("[saveRewardToFile] Error Marshalling rewards", "err", err, "rewards", rewards)
 		return
 	}
 


### PR DESCRIPTION
# Proposed changes
This PR fixes the following issue for v2 engine: The rewards filename is inaccurate if the node itself is the miner of that block
https://github.com/XinFinOrg/XDPoSChain/issues/1479


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [x] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
