### PR TITLE
miner: fix concurrent map access in `Miner.HashRate`, close XFN-52

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -145,15 +145,7 @@ func (m *Miner) HashRate() (tot int64) {
 	if pow, ok := m.engine.(consensus.PoW); ok {
 		tot += int64(pow.Hashrate())
 	}
-	// do we care this might race? is it worth we're rewriting some
-	// aspects of the worker/locking up agents so we can get an accurate
-	// hashrate?
-	for agent := range m.worker.agents {
-		if _, ok := agent.(*CpuAgent); !ok {
-			tot += agent.GetHashRate()
-		}
-	}
-	return
+	return tot + m.worker.getHashrate()
 }
 
 func (m *Miner) SetExtra(extra []byte) error {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -381,6 +381,19 @@ func (w *worker) update() {
 	}
 }
 
+func (w *worker) getHashrate() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	total := int64(0)
+	for agent := range w.agents {
+		if _, ok := agent.(*CpuAgent); !ok {
+			total += agent.GetHashRate()
+		}
+	}
+	return total
+}
+
 func getResetTime(chain *core.BlockChain, minePeriod int) time.Duration {
 	minePeriodDuration := time.Duration(minePeriod) * time.Second
 	currentBlockTime := int64(chain.CurrentBlock().Time())


### PR DESCRIPTION
# Proposed changes

fix audit issue XFN-52: Concurrent Map Access in `Miner.HashRate` Could Crash Validators

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
