### PR TITLE
common: fix gas fee mismatch before TIPTRC21Fee, close XFN-51

### DIFF
--- a/common/gas.go
+++ b/common/gas.go
@@ -13,6 +13,8 @@ func GetGasFee(blockNumber, gas uint64) *big.Int {
 		fee = fee.Mul(fee, GasPrice50x)
 	} else if blockNumber > TIPTRC21Fee.Uint64() {
 		fee = fee.Mul(fee, TRC21GasPrice)
+	} else {
+		fee = fee.Mul(fee, TRC21GasPriceBefore)
 	}
 
 	return fee

--- a/contracts/trc21issuer/trc21issuer_test.go
+++ b/contracts/trc21issuer/trc21issuer_test.go
@@ -30,6 +30,12 @@ var (
 )
 
 func TestFeeTxWithTRC21Token(t *testing.T) {
+	oldTRC21GasPriceBefore := new(big.Int).Set(common.TIPTRC21Fee)
+	defer func() {
+		common.TIPTRC21Fee = oldTRC21GasPriceBefore
+	}()
+	common.TRC21GasPriceBefore = big.NewInt(1)
+
 	// init genesis
 	contractBackend := backends.NewXDCSimulatedBackend(
 		types.GenesisAlloc{


### PR DESCRIPTION
# Proposed changes

fix audit issue XFN-51: TRC21 Fee Accounting Mismatch Before `TIPTRC21Fee` Inflates Miner Rewards

I synced with mainnet and testnet, all nodes passed block number `TIPTRC21Fee`.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
