### PR TITLE
consensus: Impose size limit for DecodeBytesExtraFields

### DIFF
--- a/consensus/XDPoS/utils/utils.go
+++ b/consensus/XDPoS/utils/utils.go
@@ -85,6 +85,11 @@ func DecodeBytesExtraFields(b []byte, val interface{}) error {
 	if len(b) == 0 {
 		return errors.New("extra field is 0 length")
 	}
+	// Prevent payload attack, limit the size of extra field to 20k bytes. Normal Extrafield payload is less than 7k bytes.
+	if len(b) > 20000 {
+		return errors.New("extra field is too long")
+	}
+
 	switch b[0] {
 	case 2:
 		return rlp.DecodeBytes(b[1:], val)


### PR DESCRIPTION
# Proposed changes
impose size limit for DecodeBytesExtraFields
Normal Extrafield payload is less than 7k bytes. Chose 20k bytes limit.

ref audit ticket: XFN-08


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
