### PR TITLE
miner: not sleep when hold multiple mutex, close XFN-40

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -596,7 +596,7 @@ func abs(x int64) int64 {
 	return x
 }
 
-func (w *worker) commitNewWork() {
+func (w *worker) checkPreCommitWithLock() (*types.Block, bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.uncleMu.Lock()
@@ -604,8 +604,10 @@ func (w *worker) commitNewWork() {
 	w.currentMu.Lock()
 	defer w.currentMu.Unlock()
 
-	tstart := time.Now()
+	return w.checkPreCommit()
+}
 
+func (w *worker) checkPreCommit() (*types.Block, bool) {
 	c := w.engine.(*XDPoS.XDPoS)
 	var parent *types.Block
 	if c != nil {
@@ -614,12 +616,11 @@ func (w *worker) commitNewWork() {
 		parent = w.chain.CurrentBlock()
 	}
 
-	var signers map[common.Address]struct{}
 	if parent.Hash().Hex() == w.lastParentBlockCommit {
-		return
+		return parent, true
 	}
 	if !w.announceTxs && atomic.LoadInt32(&w.mining) == 0 {
-		return
+		return parent, true
 	}
 
 	// Only try to commit new work if we are mining
@@ -629,14 +630,24 @@ func (w *worker) commitNewWork() {
 			ok, err := c.YourTurn(w.chain, parent.Header(), w.coinbase)
 			if err != nil {
 				log.Warn("Failed when trying to commit new work", "err", err)
-				return
+				return parent, true
 			}
 			if !ok {
 				log.Info("Not my turn to commit block. Waiting...")
-				return
+				return parent, true
 			}
 		}
 	}
+
+	return parent, false
+}
+
+func (w *worker) commitNewWork() {
+	parent, shouldReturn := w.checkPreCommitWithLock()
+	if shouldReturn {
+		return
+	}
+	tstart := time.Now()
 	tstamp := tstart.Unix()
 	if parent.Time() >= uint64(tstamp) {
 		tstamp = int64(parent.Time() + 1)
@@ -646,6 +657,18 @@ func (w *worker) commitNewWork() {
 		wait := time.Duration(tstamp-now) * time.Second
 		log.Info("Mining too far in the future", "wait", common.PrettyDuration(wait))
 		time.Sleep(wait)
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.uncleMu.Lock()
+	defer w.uncleMu.Unlock()
+	w.currentMu.Lock()
+	defer w.currentMu.Unlock()
+
+	parent, shouldReturn = w.checkPreCommit()
+	if shouldReturn {
+		return
 	}
 
 	num := parent.Number()
@@ -720,6 +743,7 @@ func (w *worker) commitNewWork() {
 			log.Error("[commitNewWork] fail to check if block is epoch switch block when fetching pending transactions", "BlockNum", header.Number, "Hash", header.Hash())
 		}
 		if !isEpochSwitchBlock {
+			var signers map[common.Address]struct{}
 			pending := w.eth.TxPool().Pending(true)
 			txs, specialTxs = types.NewTransactionsByPriceAndNonce(w.current.signer, pending, signers, feeCapacity)
 		}


### PR DESCRIPTION
# Proposed changes

fix audit issue XFN-40: Sleeping While Holding Multiple Mutex Locks Could Stalls Event Loop And Miner Operations

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
