### PR TITLE
engine_v2, params: fix unsynchronized reads of V2.CurrentConfig, close XFN-53

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -149,14 +149,15 @@ func (x *XDPoS_v2) UpdateParams(header *types.Header) {
 	x.config.V2.UpdateConfig(uint64(round))
 
 	// Setup timeoutTimer
-	duration := time.Duration(x.config.V2.CurrentConfig.TimeoutPeriod) * time.Second
-	err = x.timeoutWorker.SetParams(duration, x.config.V2.CurrentConfig.ExpTimeoutConfig.Base, x.config.V2.CurrentConfig.ExpTimeoutConfig.MaxExponent)
+	currentConfig := x.config.V2.GetCurrentConfig()
+	duration := time.Duration(currentConfig.TimeoutPeriod) * time.Second
+	err = x.timeoutWorker.SetParams(duration, currentConfig.ExpTimeoutConfig.Base, currentConfig.ExpTimeoutConfig.MaxExponent)
 	if err != nil {
 		log.Error("[UpdateParams] set params failed", "err", err)
 	}
 	// avoid deadlock
 	go func() {
-		x.minePeriodCh <- x.config.V2.CurrentConfig.MinePeriod
+		x.minePeriodCh <- currentConfig.MinePeriod
 	}()
 }
 
@@ -258,10 +259,11 @@ func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) er
 	}
 
 	// Initial timeout
-	log.Warn("[initial] miner wait period", "period", x.config.V2.CurrentConfig.MinePeriod)
+	currentConfig := x.config.V2.GetCurrentConfig()
+	log.Warn("[initial] miner wait period", "period", currentConfig.MinePeriod)
 	// avoid deadlock
 	go func() {
-		x.minePeriodCh <- x.config.V2.CurrentConfig.MinePeriod
+		x.minePeriodCh <- currentConfig.MinePeriod
 	}()
 
 	// Kick-off the countdown timer

--- a/consensus/XDPoS/engines/engine_v2/timeout.go
+++ b/consensus/XDPoS/engines/engine_v2/timeout.go
@@ -323,7 +323,7 @@ func (x *XDPoS_v2) OnCountdownTimeout(time time.Time, chain interface{}) error {
 	}
 
 	x.timeoutCount++
-	if x.timeoutCount%x.config.V2.CurrentConfig.TimeoutSyncThreshold == 0 {
+	if x.timeoutCount%x.config.V2.GetCurrentConfig().TimeoutSyncThreshold == 0 {
 		syncInfo := x.getSyncInfo()
 		log.Info("[OnCountdownTimeout] Timeout sync threshold reached, send syncInfo message", "QC round", syncInfo.HighestQuorumCert.ProposedBlockInfo.Round, "QC num", syncInfo.HighestQuorumCert.ProposedBlockInfo.Number, "QC sigs", len(syncInfo.HighestQuorumCert.Signatures), "TC round", syncInfo.HighestTimeoutCert.Round, "TC sigs", len(syncInfo.HighestTimeoutCert.Signatures))
 		x.broadcastToBftChannel(syncInfo)

--- a/params/config.go
+++ b/params/config.go
@@ -548,7 +548,7 @@ func (v2 *V2) Description(indent int) string {
 	banner += fmt.Sprintf("%s- SwitchEpoch: %v\n", prefix, v2.SwitchEpoch)
 	banner += fmt.Sprintf("%s- SwitchBlock: %v\n", prefix, v2.SwitchBlock)
 	banner += fmt.Sprintf("%s- SkipV2Validation: %v\n", prefix, v2.SkipV2Validation)
-	banner += fmt.Sprintf("%s- %s", prefix, v2.CurrentConfig.Description("CurrentConfig", indent+2))
+	banner += fmt.Sprintf("%s- %s", prefix, v2.GetCurrentConfig().Description("CurrentConfig", indent+2))
 	return banner
 }
 
@@ -599,6 +599,20 @@ func (v2 *V2) UpdateConfig(round uint64) {
 	// update to current config
 	log.Info("[updateV2Config] Update config", "index", index, "round", round, "SwitchRound", v2.AllConfigs[index].SwitchRound)
 	v2.CurrentConfig = v2.AllConfigs[index]
+}
+
+// GetCurrentConfig returns a opy of the current config, it assumes v2 is not nil
+func (v2 *V2) GetCurrentConfig() *V2Config {
+	v2.lock.RLock()
+	defer v2.lock.RUnlock()
+
+	if v2.CurrentConfig == nil {
+		return nil
+	}
+
+	// avoid CurrentConfig is changed by other goroutines
+	cpyConfig := *v2.CurrentConfig
+	return &cpyConfig
 }
 
 func (v2 *V2) Config(round uint64) *V2Config {


### PR DESCRIPTION
# Proposed changes

fix audit issue XFN-53: Unsynchronized Reads Of V2.CurrentConfig Can Cause Transient Parameter Jitter

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
