### PR TITLE
consensus/XDPoS: avoid use len as variable, close XFN-25

### DIFF
--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -399,7 +399,7 @@ func (x *XDPoS_v1) whoIsCreator(snap *SnapshotV1, header *types.Header) (common.
 	return m, nil
 }
 func (x *XDPoS_v1) YourTurn(chain consensus.ChainReader, parent *types.Header, signer common.Address) (bool, error) {
-	len, preIndex, curIndex, ok, err := x.yourTurn(chain, parent, signer)
+	length, preIndex, curIndex, ok, err := x.yourTurn(chain, parent, signer)
 
 	if err != nil {
 		log.Warn("Failed when trying to commit new work", "err", err)
@@ -415,7 +415,7 @@ func (x *XDPoS_v1) YourTurn(chain consensus.ChainReader, parent *types.Header, s
 			// you're not allowed to create this block
 			return false, nil
 		}
-		h := utils.Hop(len, preIndex, curIndex)
+		h := utils.Hop(length, preIndex, curIndex)
 		gap := minePeriod * int64(h)
 		// Check nearest checkpoint block in hop range.
 		nearest := x.config.Epoch - (parent.Number.Uint64() % x.config.Epoch)
@@ -955,11 +955,11 @@ func (x *XDPoS_v1) calcDifficulty(chain consensus.ChainReader, parent *types.Hea
 	if x.config.SkipV1Validation {
 		return big.NewInt(1)
 	}
-	len, preIndex, curIndex, _, err := x.yourTurn(chain, parent, signer)
+	length, preIndex, curIndex, _, err := x.yourTurn(chain, parent, signer)
 	if err != nil {
-		return big.NewInt(int64(len + curIndex - preIndex))
+		return big.NewInt(int64(length + curIndex - preIndex))
 	}
-	return big.NewInt(int64(len - utils.Hop(len, preIndex, curIndex)))
+	return big.NewInt(int64(length - utils.Hop(length, preIndex, curIndex)))
 }
 
 func (x *XDPoS_v1) RecoverSigner(header *types.Header) (common.Address, error) {

--- a/consensus/XDPoS/utils/utils.go
+++ b/consensus/XDPoS/utils/utils.go
@@ -22,14 +22,14 @@ func Position(list []common.Address, x common.Address) int {
 	return -1
 }
 
-func Hop(len, pre, cur int) int {
+func Hop(length, preIndex, curIndex int) int {
 	switch {
-	case pre < cur:
-		return cur - (pre + 1)
-	case pre > cur:
-		return (len - pre) + (cur - 1)
+	case preIndex < curIndex:
+		return curIndex - (preIndex + 1)
+	case preIndex > curIndex:
+		return (length - preIndex) + (curIndex - 1)
 	default:
-		return len - 1
+		return length - 1
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

fix audit issue XFN-25: `Hop` Helper Lacks Defensive Input Guards

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
