### PR TITLE
XDPoS/utils: must use `NewPool()` to create Pool, close XFN-13

### DIFF
--- a/consensus/XDPoS/utils/pool.go
+++ b/consensus/XDPoS/utils/pool.go
@@ -21,13 +21,24 @@ func NewPool() *Pool {
 		objList: make(map[string]map[common.Hash]PoolObj),
 	}
 }
+
+func (p *Pool) ensureInit() {
+	if p != nil && p.objList == nil {
+		panic("Pool must be inited by NewPool()")
+	}
+}
+
 func (p *Pool) Get() map[string]map[common.Hash]PoolObj {
+	p.ensureInit()
+
 	return p.objList
 }
 
 func (p *Pool) Add(obj PoolObj) (int, map[common.Hash]PoolObj) {
+	p.ensureInit()
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
 	poolKey := obj.PoolKey()
 	objListKeyed, ok := p.objList[poolKey]
 	if !ok {
@@ -40,6 +51,8 @@ func (p *Pool) Add(obj PoolObj) (int, map[common.Hash]PoolObj) {
 }
 
 func (p *Pool) Size(obj PoolObj) int {
+	p.ensureInit()
+
 	poolKey := obj.PoolKey()
 	objListKeyed, ok := p.objList[poolKey]
 	if !ok {
@@ -49,6 +62,7 @@ func (p *Pool) Size(obj PoolObj) int {
 }
 
 func (p *Pool) PoolObjKeysList() []string {
+	p.ensureInit()
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
@@ -61,6 +75,7 @@ func (p *Pool) PoolObjKeysList() []string {
 
 // Given the pool object, clear all object under the same pool key
 func (p *Pool) ClearPoolKeyByObj(obj PoolObj) {
+	p.ensureInit()
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -70,6 +85,7 @@ func (p *Pool) ClearPoolKeyByObj(obj PoolObj) {
 
 // Given the pool key, clean its content
 func (p *Pool) ClearByPoolKey(poolKey string) {
+	p.ensureInit()
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -77,6 +93,7 @@ func (p *Pool) ClearByPoolKey(poolKey string) {
 }
 
 func (p *Pool) Clear() {
+	p.ensureInit()
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -84,6 +101,7 @@ func (p *Pool) Clear() {
 }
 
 func (p *Pool) GetObjsByKey(poolKey string) []PoolObj {
+	p.ensureInit()
 	p.lock.Lock()
 	defer p.lock.Unlock()
 


### PR DESCRIPTION
# Proposed changes

fix audit finding XFN-13: Zero-value `Pool` May Panic on Write

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
