### PR TITLE
XDPoS/utils: use `strconv.ParseInt` to convert int64, close XFN-24

### DIFF
--- a/consensus/XDPoS/utils/utils.go
+++ b/consensus/XDPoS/utils/utils.go
@@ -42,12 +42,12 @@ func ExtractValidatorsFromBytes(byteValidators []byte) ([]int64, error) {
 	var validators []int64
 	for i := 0; i < lenValidator; i++ {
 		trimByte := bytes.Trim(byteValidators[i*M2ByteLength:(i+1)*M2ByteLength], "\x00")
-		intNumber, err := strconv.Atoi(string(trimByte))
+		intNumber, err := strconv.ParseInt(string(trimByte), 10, 64)
 		if err != nil {
 			log.Error("Can not convert string to integer", "error", err)
 			return []int64{}, fmt.Errorf("can not convert string %s to integer: %v", string(trimByte), err)
 		}
-		validators = append(validators, int64(intNumber))
+		validators = append(validators, intNumber)
 	}
 
 	return validators, nil


### PR DESCRIPTION
# Proposed changes

fix audit finding XFN-24: Platform Dependent Integer Conversion

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
