### PR TITLE
XDPoS/utils: get pool size by key, close XFN-21

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/testing_utils.go
+++ b/consensus/XDPoS/engines/engine_v2/testing_utils.go
@@ -36,12 +36,12 @@ func (x *XDPoS_v2) GetCurrentRoundFaker() types.Round {
 
 // Utils for test to get current Pool size
 func (x *XDPoS_v2) GetVotePoolSizeFaker(vote *types.Vote) int {
-	return x.votePool.Size(vote)
+	return x.votePool.Size(vote.PoolKey())
 }
 
 // Utils for test to get Timeout Pool Size
 func (x *XDPoS_v2) GetTimeoutPoolSizeFaker(timeout *types.Timeout) int {
-	return x.timeoutPool.Size(timeout)
+	return x.timeoutPool.Size(timeout.PoolKey())
 }
 
 // WARN: This function is designed for testing purpose only!

--- a/consensus/XDPoS/utils/pool.go
+++ b/consensus/XDPoS/utils/pool.go
@@ -56,10 +56,10 @@ func (p *Pool) Add(obj PoolObj) (int, map[common.Hash]PoolObj) {
 	return numOfItems, dataCopy
 }
 
-func (p *Pool) Size(obj PoolObj) int {
+func (p *Pool) Size(poolKey string) int {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
-	poolKey := obj.PoolKey()
+
 	objListKeyed, ok := p.objList[poolKey]
 	if !ok {
 		return 0


### PR DESCRIPTION
# Proposed changes

fix audit finding XFN-21: `Pool.Size` Requires Full Object Instead of Key

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
