### PR TITLE
XDPoS/utils: must use `NewPool()` to create Pool, close XFN-13

### DIFF
--- a/consensus/XDPoS/utils/pool.go
+++ b/consensus/XDPoS/utils/pool.go
@@ -11,6 +11,8 @@ type PoolObj interface {
 	PoolKey() string
 	GetSigner() common.Address
 }
+
+// Note: must use `NewPool()` to create `Pool` since field `objList` is a map
 type Pool struct {
 	objList map[string]map[common.Hash]PoolObj
 	lock    sync.RWMutex // Protects the pool fields
@@ -21,6 +23,7 @@ func NewPool() *Pool {
 		objList: make(map[string]map[common.Hash]PoolObj),
 	}
 }
+
 func (p *Pool) Get() map[string]map[common.Hash]PoolObj {
 	return p.objList
 }


### PR DESCRIPTION
# Proposed changes

fix audit finding XFN-13: Zero-value `Pool` May Panic on Write

replace #1657

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
