### PR TITLE
core, miner: fix inconsistent tx blacklist enforcement, close XFN-98

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -94,7 +94,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, tra
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		// check black-list txs after hf
-		if (block.Number().Uint64() >= common.BlackListHFNumber) && !common.IsTestnet {
+		if block.Number().Uint64() >= common.BlackListHFNumber {
 			// check if sender is in black list
 			if common.IsInBlacklist(tx.From()) {
 				return nil, nil, 0, fmt.Errorf("block contains transaction with sender in black-list: %v", tx.From().Hex())
@@ -187,7 +187,7 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 	receipts = make([]*types.Receipt, block.Transactions().Len())
 	for i, tx := range block.Transactions() {
 		// check black-list txs after hf
-		if (block.Number().Uint64() >= common.BlackListHFNumber) && !common.IsTestnet {
+		if block.Number().Uint64() >= common.BlackListHFNumber {
 			// check if sender is in black list
 			if common.IsInBlacklist(tx.From()) {
 				return nil, nil, 0, fmt.Errorf("block contains transaction with sender in black-list: %v", tx.From().Hex())

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -630,13 +630,20 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if uint64(tx.Size()) > txMaxSize {
 		return ErrOversizedData
 	}
-	// check if sender is in black list
-	if common.IsInBlacklist(tx.From()) {
-		return fmt.Errorf("reject transaction with sender in black-list: %v", tx.From().Hex())
+	// Get current block number
+	var number *big.Int = nil
+	if pool.chain.CurrentHeader() != nil {
+		number = pool.chain.CurrentHeader().Number
 	}
-	// check if receiver is in black list
-	if common.IsInBlacklist(tx.To()) {
-		return fmt.Errorf("reject transaction with receiver in black-list: %v", tx.To().Hex())
+	if number == nil || number.Uint64() >= common.BlackListHFNumber {
+		// check if sender is in black list
+		if common.IsInBlacklist(tx.From()) {
+			return fmt.Errorf("reject transaction with sender in black-list: %v", tx.From().Hex())
+		}
+		// check if receiver is in black list
+		if common.IsInBlacklist(tx.To()) {
+			return fmt.Errorf("reject transaction with receiver in black-list: %v", tx.To().Hex())
+		}
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur if you create a transaction using the RPC.
@@ -691,10 +698,6 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// cost == V + GP * GL
 	balance := pool.currentState.GetBalance(from)
 	cost := tx.Cost()
-	var number *big.Int = nil
-	if pool.chain.CurrentHeader() != nil {
-		number = pool.chain.CurrentHeader().Number
-	}
 	minGasPrice := common.GetMinGasPrice(number)
 	feeCapacity := big.NewInt(0)
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -889,8 +889,7 @@ func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Addr
 	// first priority for special Txs
 	for _, tx := range specialTxs {
 		to := tx.To()
-		//HF number for black-list
-		if (w.header.Number.Uint64() >= common.BlackListHFNumber) && !common.IsTestnet {
+		if w.header.Number.Uint64() >= common.BlackListHFNumber {
 			from := tx.From()
 			// check if sender is in black list
 			if common.IsInBlacklist(from) {
@@ -1001,9 +1000,8 @@ func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Addr
 			break
 		}
 
-		//HF number for black-list
 		to := tx.To()
-		if (w.header.Number.Uint64() >= common.BlackListHFNumber) && !common.IsTestnet {
+		if w.header.Number.Uint64() >= common.BlackListHFNumber {
 			from := tx.From()
 			// check if sender is in black list
 			if common.IsInBlacklist(from) {


### PR DESCRIPTION
# Proposed changes

fix audit finding XFN-98: Inconsistent Blacklist Enforcement Between `txpool` and `state_processor`

synced with mainnet and testnet, both of them passed block `BlackListHFNumber`

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
