### PR TITLE
tracers, consensus/clique: use maps.Clone #29616

### DIFF
--- a/consensus/clique/snapshot.go
+++ b/consensus/clique/snapshot.go
@@ -19,6 +19,8 @@ package clique
 import (
 	"bytes"
 	"encoding/json"
+	"maps"
+	"slices"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/lru"
@@ -104,28 +106,16 @@ func (s *Snapshot) store(db ethdb.Database) error {
 
 // copy creates a deep copy of the snapshot, though not the individual votes.
 func (s *Snapshot) copy() *Snapshot {
-	cpy := &Snapshot{
+	return &Snapshot{
 		config:   s.config,
 		sigcache: s.sigcache,
 		Number:   s.Number,
 		Hash:     s.Hash,
-		Signers:  make(map[common.Address]struct{}),
-		Recents:  make(map[uint64]common.Address),
-		Votes:    make([]*Vote, len(s.Votes)),
-		Tally:    make(map[common.Address]Tally),
+		Signers:  maps.Clone(s.Signers),
+		Recents:  maps.Clone(s.Recents),
+		Votes:    slices.Clone(s.Votes),
+		Tally:    maps.Clone(s.Tally),
 	}
-	for signer := range s.Signers {
-		cpy.Signers[signer] = struct{}{}
-	}
-	for block, signer := range s.Recents {
-		cpy.Recents[block] = signer
-	}
-	for address, tally := range s.Tally {
-		cpy.Tally[address] = tally
-	}
-	copy(cpy.Votes, s.Votes)
-
-	return cpy
 }
 
 // validVote returns whether it makes sense to cast the specified vote in the

--- a/trie/utils.go
+++ b/trie/utils.go
@@ -16,6 +16,12 @@
 
 package trie
 
+import (
+	"maps"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+)
+
 // tracer tracks the changes of trie nodes. During the trie operations,
 // some nodes can be deleted from the trie, while these deleted nodes
 // won't be captured by trie.Hasher or trie.Committer. Thus, these deleted
@@ -141,24 +147,19 @@ func (t *tracer) reset() {
 
 // copy returns a deep copied tracer instance.
 func (t *tracer) copy() *tracer {
-	// Tracer isn't used right now, remove this check later.
 	if t == nil {
 		return nil
 	}
-	var (
-		insert = make(map[string]struct{})
-		delete = make(map[string]struct{})
-		origin = make(map[string][]byte)
-	)
-	for key := range t.insert {
-		insert[key] = struct{}{}
+
+	insert := maps.Clone(t.insert)
+	delete := maps.Clone(t.delete)
+
+	origin := make(map[string][]byte, len(t.origin))
+	for k, v := range t.origin {
+		// `common.CopyBytes` ensures deep copy according to comment
+		origin[k] = common.CopyBytes(v)
 	}
-	for key := range t.delete {
-		delete[key] = struct{}{}
-	}
-	for key, val := range t.origin {
-		origin[key] = val
-	}
+
 	return &tracer{
 		insert: insert,
 		delete: delete,


### PR DESCRIPTION
# Proposed changes

tracers, consensus/clique: 

- use `maps.Clone` to simplify the code
- use 'common.CopyBytes' to fix a bug about deep copy in the function ` (t *tracer) copy()`.

Ref: #29616

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
