### PR TITLE
rpc: fix flaky test TestServerWebsocketReadLimit #32889

### DIFF
--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -273,7 +273,8 @@ func TestServerWebsocketReadLimit(t *testing.T) {
 					}
 				} else if !errors.Is(err, websocket.ErrReadLimit) &&
 					!strings.Contains(strings.ToLower(err.Error()), "1009") &&
-					!strings.Contains(strings.ToLower(err.Error()), "message too big") {
+					!strings.Contains(strings.ToLower(err.Error()), "message too big") &&
+					!strings.Contains(strings.ToLower(err.Error()), "connection reset by peer") {
 					// Not the error we expect from exceeding the message size limit.
 					t.Fatalf("unexpected error for read limit violation: %v", err)
 				}


### PR DESCRIPTION
# Proposed changes

rpc: fix flaky test TestServerWebsocketReadLimit #32889

Ref: #32889

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
