### PR TITLE
all: replace `strings.Split` with more efficient `strings.SplitSeq`

### DIFF
--- a/cmd/XDC/config.go
+++ b/cmd/XDC/config.go
@@ -176,7 +176,7 @@ func loadBaseConfig(ctx *cli.Context) XDCConfig {
 	for _, env := range cfg.Account.Passwords {
 		if trimmed := strings.TrimSpace(env); trimmed != "" {
 			value := os.Getenv(trimmed)
-			for _, info := range strings.Split(value, ",") {
+			for info := range strings.SplitSeq(value, ",") {
 				if trimmed2 := strings.TrimSpace(info); trimmed2 != "" {
 					passwords = append(passwords, trimmed2)
 				}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1826,7 +1826,7 @@ func MakeConsolePreloads(ctx *cli.Context) []string {
 	preloads := []string{}
 
 	assets := ctx.String(JSpathFlag.Name)
-	for _, file := range strings.Split(ctx.String(PreloadJSFlag.Name), ",") {
+	for file := range strings.SplitSeq(ctx.String(PreloadJSFlag.Name), ",") {
 		preloads = append(preloads, common.AbsolutePath(assets, strings.TrimSpace(file)))
 	}
 	return preloads

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -131,7 +131,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	common.CopyConstants(networkID)
 
 	log.Info(strings.Repeat("-", 153))
-	for _, line := range strings.Split(chainConfig.Description(), "\n") {
+	for line := range strings.SplitSeq(chainConfig.Description(), "\n") {
 		log.Info(line)
 	}
 	log.Info(strings.Repeat("-", 153))

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -86,7 +86,7 @@ func (h *GlogHandler) Verbosity(level slog.Level) {
 //	 sets V to 3 in all files of any packages whose import path contains "foo"
 func (h *GlogHandler) Vmodule(ruleset string) error {
 	var filter []pattern
-	for _, rule := range strings.Split(ruleset, ",") {
+	for rule := range strings.SplitSeq(ruleset, ",") {
 		// Empty strings such as from a trailing comma can be ignored
 		if len(rule) == 0 {
 			continue
@@ -113,7 +113,7 @@ func (h *GlogHandler) Vmodule(ruleset string) error {
 		}
 		// Compile the rule pattern into a regular expression
 		matcher := ".*"
-		for _, comp := range strings.Split(parts[0], "/") {
+		for comp := range strings.SplitSeq(parts[0], "/") {
 			if comp == "*" {
 				matcher += "(/.*)?"
 			} else if comp != "" {

--- a/node/api.go
+++ b/node/api.go
@@ -205,19 +205,19 @@ func (api *adminAPI) StartHTTP(host *string, port *int, cors *string, apis *stri
 	}
 	if cors != nil {
 		config.CorsAllowedOrigins = nil
-		for _, origin := range strings.Split(*cors, ",") {
+		for origin := range strings.SplitSeq(*cors, ",") {
 			config.CorsAllowedOrigins = append(config.CorsAllowedOrigins, strings.TrimSpace(origin))
 		}
 	}
 	if vhosts != nil {
 		config.Vhosts = nil
-		for _, vhost := range strings.Split(*host, ",") {
+		for vhost := range strings.SplitSeq(*host, ",") {
 			config.Vhosts = append(config.Vhosts, strings.TrimSpace(vhost))
 		}
 	}
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
@@ -283,13 +283,13 @@ func (api *adminAPI) StartWS(host *string, port *int, allowedOrigins *string, ap
 
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
 	if allowedOrigins != nil {
 		config.Origins = nil
-		for _, origin := range strings.Split(*allowedOrigins, ",") {
+		for origin := range strings.SplitSeq(*allowedOrigins, ",") {
 			config.Origins = append(config.Origins, strings.TrimSpace(origin))
 		}
 	}

--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -480,13 +480,13 @@ func (s *Server) StreamNetworkEvents(w http.ResponseWriter, req *http.Request) {
 // A message code of '*' or '-1' is considered a wildcard and matches any code.
 func NewMsgFilters(filterParam string) (MsgFilters, error) {
 	filters := make(MsgFilters)
-	for _, filter := range strings.Split(filterParam, "-") {
+	for filter := range strings.SplitSeq(filterParam, "-") {
 		proto, codes, found := strings.Cut(filter, ":")
 		if !found || proto == "" || codes == "" {
 			return nil, fmt.Errorf("invalid message filter: %s", filter)
 		}
 
-		for _, code := range strings.Split(codes, ",") {
+		for code := range strings.SplitSeq(codes, ",") {
 			if code == "*" || code == "-1" {
 				filters[MsgFilter{Proto: proto, Code: -1}] = struct{}{}
 				continue

--- a/rlp/internal/rlpstruct/rlpstruct.go
+++ b/rlp/internal/rlpstruct/rlpstruct.go
@@ -148,7 +148,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 	name := field.Name
 	tag := reflect.StructTag(field.Tag)
 	var ts Tags
-	for _, t := range strings.Split(tag.Get("rlp"), ",") {
+	for t := range strings.SplitSeq(tag.Get("rlp"), ",") {
 		switch t = strings.TrimSpace(t); t {
 		case "":
 			// empty tag is allowed for some reason

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -92,7 +92,7 @@ func runTestScript(t *testing.T, file string) {
 	defer clientConn.Close()
 	go server.ServeCodec(NewCodec(serverConn), 0)
 	readbuf := bufio.NewReader(clientConn)
-	for _, line := range strings.Split(string(content), "\n") {
+	for line := range strings.SplitSeq(string(content), "\n") {
 		line = strings.TrimSpace(line)
 		switch {
 		case len(line) == 0 || strings.HasPrefix(line, "//"):


### PR DESCRIPTION
# Proposed changes

**Notice: `strings.SplitSeq()` is introduced in Go 1.24**

The `strings.SplitSeq` function in Go is a new addition (introduced in Go 1.24) that provides an iterator for splitting a string. Unlike `strings.Split`, which returns a []string (a slice of strings), `SplitSeq` returns a single-use iterator. This iterator yields the same substrings that Split would produce, but it does so without constructing the entire slice in memory at once.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
