### PR TITLE
eth/hooks: use slices.SortStableFunc in engine_v2

### DIFF
--- a/eth/hooks/engine_v2_hooks.go
+++ b/eth/hooks/engine_v2_hooks.go
@@ -3,10 +3,10 @@ package hooks
 import (
 	"errors"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
-	"github.com/XinFinOrg/XDPoSChain/common/sort"
 	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
@@ -428,8 +428,8 @@ func GetSigningTxCount(c *XDPoS.XDPoS, chain consensus.ChainReader, header *type
 							ms = append(ms, utils.Masternode{Address: candidate, Stake: v})
 						}
 					}
-					sort.Slice(ms, func(i, j int) bool {
-						return ms[i].Stake.Cmp(ms[j].Stake) >= 0
+					slices.SortStableFunc(ms, func(a, b utils.Masternode) int {
+						return b.Stake.Cmp(a.Stake)
 					})
 					// find penalty and filter them out
 					penalties := common.ExtractAddressFromBytes(h.Penalties)


### PR DESCRIPTION
# Proposed changes

The package "github.com/XinFinOrg/XDPoSChain/common/sort" was imported accidentally in PR #865. We should use it in new code since it was implemented in PR #338 which based on golang v1.18. The new code should use package slices to do sorting.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
