### PR TITLE
cmd/XDC, metrics/prometheus: fix staticcheck QF1012

### DIFF
--- a/cmd/XDC/consolecmd.go
+++ b/cmd/XDC/consolecmd.go
@@ -167,7 +167,7 @@ func remoteConsole(ctx *cli.Context) error {
 func ephemeralConsole(ctx *cli.Context) error {
 	var b strings.Builder
 	for _, file := range ctx.Args().Slice() {
-		b.WriteString(fmt.Sprintf("loadScript('%s');", file))
+		fmt.Fprintf(&b, "loadScript('%s');", file)
 	}
 	utils.Fatalf(`The "js" command is deprecated. Please use the following instead:
 XDC --exec "%s" console`, b.String())

--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -99,7 +99,7 @@ func (c *collector) addHistogram(name string, m metrics.HistogramSnapshot) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
 	c.writeSummaryCounter(name, m.Count())
-	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
+	fmt.Fprintf(c.buff, typeSummaryTpl, mutateKey(name))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
@@ -114,7 +114,7 @@ func (c *collector) addTimer(name string, m *metrics.TimerSnapshot) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
 	c.writeSummaryCounter(name, m.Count())
-	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
+	fmt.Fprintf(c.buff, typeSummaryTpl, mutateKey(name))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
@@ -128,7 +128,7 @@ func (c *collector) addResettingTimer(name string, m *metrics.ResettingTimerSnap
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
 	c.writeSummaryCounter(name, m.Count())
-	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
+	fmt.Fprintf(c.buff, typeSummaryTpl, mutateKey(name))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
@@ -137,7 +137,7 @@ func (c *collector) addResettingTimer(name string, m *metrics.ResettingTimerSnap
 
 func (c *collector) writeGaugeInfo(name string, value metrics.GaugeInfoValue) {
 	name = mutateKey(name)
-	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, name))
+	fmt.Fprintf(c.buff, typeGaugeTpl, name)
 	c.buff.WriteString(name)
 	c.buff.WriteString(" ")
 	kvs := make([]string, 0, len(value))
@@ -145,24 +145,24 @@ func (c *collector) writeGaugeInfo(name string, value metrics.GaugeInfoValue) {
 		kvs = append(kvs, fmt.Sprintf("%v=%q", k, v))
 	}
 	slices.Sort(kvs)
-	c.buff.WriteString(fmt.Sprintf("{%v} 1\n\n", strings.Join(kvs, ", ")))
+	fmt.Fprintf(c.buff, "{%v} 1\n\n", strings.Join(kvs, ", "))
 }
 
 func (c *collector) writeGaugeCounter(name string, value interface{}) {
 	name = mutateKey(name)
-	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, name))
-	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
+	fmt.Fprintf(c.buff, typeGaugeTpl, name)
+	fmt.Fprintf(c.buff, keyValueTpl, name, value)
 }
 
 func (c *collector) writeSummaryCounter(name string, value interface{}) {
 	name = mutateKey(name + "_count")
-	c.buff.WriteString(fmt.Sprintf(typeCounterTpl, name))
-	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
+	fmt.Fprintf(c.buff, typeCounterTpl, name)
+	fmt.Fprintf(c.buff, keyValueTpl, name, value)
 }
 
 func (c *collector) writeSummaryPercentile(name, p string, value interface{}) {
 	name = mutateKey(name)
-	c.buff.WriteString(fmt.Sprintf(keyQuantileTagValueTpl, name, p, value))
+	fmt.Fprintf(c.buff, keyQuantileTagValueTpl, name, p, value)
 }
 
 func mutateKey(key string) string {


### PR DESCRIPTION
# Proposed changes

Use `fmt.Fprintf(x, ...)` instead of `x.Write(fmt.Sprintf(...))`

Ref: https://staticcheck.dev/docs/checks/#QF1012

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
