### PR TITLE
consensus/XDPoS/utils: remove unused errors, close XFN-122

### DIFF
--- a/consensus/XDPoS/utils/errors.go
+++ b/consensus/XDPoS/utils/errors.go
@@ -70,9 +70,6 @@ var (
 	// be modified via out-of-range or non-contiguous headers.
 	ErrInvalidVotingChain = errors.New("invalid voting chain")
 
-	ErrInvalidHeaderOrder = errors.New("invalid header order")
-	ErrInvalidChild       = errors.New("invalid header child")
-
 	// errUnauthorized is returned if a header is signed by a non-authorized entity.
 	ErrUnauthorized = errors.New("unauthorized")
 
@@ -92,7 +89,6 @@ var (
 	ErrInvalidQCSignatures           = errors.New("invalid QC Signatures")
 	ErrInvalidTC                     = errors.New("invalid TC content")
 	ErrInvalidTCSignatures           = errors.New("invalid TC Signatures")
-	ErrEmptyBlockInfoHash            = errors.New("blockInfo hash is empty")
 	ErrInvalidFieldInNonEpochSwitch  = errors.New("invalid field exist in a non-epoch swtich block")
 	ErrValidatorNotWithinMasternodes = errors.New("validator address is not in the master node list")
 	ErrCoinbaseAndValidatorMismatch  = errors.New("validator and coinbase address in header does not match")


### PR DESCRIPTION
# Proposed changes

fix audit finding XFN-122: Unused Errors

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
