### PR TITLE
consensus: implement DeepCopy() in PoolObj, close XFN-04

### DIFF
--- a/consensus/XDPoS/utils/pool.go
+++ b/consensus/XDPoS/utils/pool.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"maps"
 	"sync"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -26,11 +25,11 @@ func NewPool() *Pool {
 func (p *Pool) Get() map[string]map[common.Hash]PoolObj {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
-	dataCopy := maps.Clone(p.objList)
-	for k, v := range dataCopy {
-		dataCopy[k] = make(map[common.Hash]PoolObj, len(dataCopy[k]))
-		for k2, v2 := range v {
-			dataCopy[k][k2] = v2.DeepCopy().(PoolObj)			
+	dataCopy := make(map[string]map[common.Hash]PoolObj, len(p.objList))
+	for k1, v1 := range p.objList {
+		dataCopy[k1] = make(map[common.Hash]PoolObj, len(v1))
+		for k2, v2 := range v1 {
+			dataCopy[k1][k2] = v2.DeepCopy().(PoolObj)
 		}
 	}
 
@@ -49,8 +48,8 @@ func (p *Pool) Add(obj PoolObj) (int, map[common.Hash]PoolObj) {
 	objListKeyed[obj.Hash()] = obj
 	numOfItems := len(objListKeyed)
 
-	dataCopy := maps.Clone(objListKeyed)
-	for k, v := range dataCopy {
+	dataCopy := make(map[common.Hash]PoolObj, len(objListKeyed))
+	for k, v := range objListKeyed {
 		dataCopy[k] = v.DeepCopy().(PoolObj)
 	}
 
@@ -115,7 +114,7 @@ func (p *Pool) GetObjsByKey(poolKey string) []PoolObj {
 	cnt := 0
 	for _, obj := range objListKeyed {
 		objList[cnt] = obj.DeepCopy().(PoolObj)
-		cnt += 1
+		cnt++
 	}
 	return objList
 }

--- a/core/types/consensus_v2.go
+++ b/core/types/consensus_v2.go
@@ -12,6 +12,12 @@ import (
 type Round uint64
 type Signature []byte
 
+func (s Signature) DeepCopy() interface{} {
+	cpy := make([]byte, len(s))
+	copy(cpy, s)
+	return s
+}
+
 // Block Info struct in XDPoS 2.0, used for vote message, etc.
 type BlockInfo struct {
 	Hash   common.Hash `json:"hash"`
@@ -36,7 +42,7 @@ func (v *Vote) DeepCopy() interface{} {
 	return &Vote{
 		signer:            v.signer,
 		ProposedBlockInfo: proposedBlockInfoCopy,
-		Signature:         append([]byte(nil), v.Signature...),
+		Signature:         v.Signature.DeepCopy().(Signature),
 		GapNumber:         v.GapNumber,
 	}
 }
@@ -70,7 +76,7 @@ func (t *Timeout) DeepCopy() interface{} {
 	return &Timeout{
 		signer:    t.signer,
 		Round:     t.Round,
-		Signature: append([]byte(nil), t.Signature...),
+		Signature: t.Signature.DeepCopy().(Signature),
 		GapNumber: t.GapNumber,
 	}
 }
@@ -103,7 +109,7 @@ func (s *SyncInfo) DeepCopy() interface{} {
 	if s.HighestQuorumCert != nil {
 		sigsCopy := make([]Signature, len(s.HighestQuorumCert.Signatures))
 		for i, sig := range s.HighestQuorumCert.Signatures {
-			sigsCopy[i] = append([]byte(nil), sig...)
+			sigsCopy[i] = sig.DeepCopy().(Signature)
 		}
 		highestQCCopy = &QuorumCert{
 			ProposedBlockInfo: &BlockInfo{
@@ -120,7 +126,7 @@ func (s *SyncInfo) DeepCopy() interface{} {
 	if s.HighestTimeoutCert != nil {
 		sigsCopy := make([]Signature, len(s.HighestTimeoutCert.Signatures))
 		for i, sig := range s.HighestTimeoutCert.Signatures {
-			sigsCopy[i] = append([]byte(nil), sig...)
+			sigsCopy[i] = sig.DeepCopy().(Signature)
 		}
 		highestTimeoutCopy = &TimeoutCert{
 			Round:      s.HighestTimeoutCert.Round,


### PR DESCRIPTION
# Proposed changes
Implement and use deep copies in PoolObj methods to prevent data race and optimize sync locks

ref audit ticket: XFN-04

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
