### PR TITLE
eth/tracers: fix unsafe pointer manipulation for slice creation, close XFN-91

### DIFF
--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -44,13 +44,9 @@ const bigIntegerJS = `var bigInt=function(undefined){"use strict";var BASE=1e7,L
 // If those are duktape stack items, popping them off **will** make the slice
 // contents change.
 func makeSlice(ptr unsafe.Pointer, size uint) []byte {
-	var sl = struct {
-		addr uintptr
-		len  int
-		cap  int
-	}{uintptr(ptr), int(size), int(size)}
-
-	return *(*[]byte)(unsafe.Pointer(&sl))
+	// This is the preferred, officially supported, and safer way
+	// to create a slice from a raw pointer in modern Go versions.
+	return unsafe.Slice((*byte)(ptr), int(size))
 }
 
 // popSlice pops a buffer off the JavaScript stack and returns it as a slice.


### PR DESCRIPTION
# Proposed changes

fix audit finding XFN-91: Memory Corruption Risk due to Unsafe Pointer Manipulation for Slice Creation

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
