### PR TITLE
core/types, miner: remove unused parameter `signers` for `NewTransactionsByPriceAndNonce()`

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -711,7 +711,7 @@ type TransactionsByPriceAndNonce struct {
 // if after providing it to the constructor.
 //
 // It also classifies special txs and normal txs
-func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions, signers map[common.Address]struct{}, payersSwap map[common.Address]*big.Int) (*TransactionsByPriceAndNonce, Transactions) {
+func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions, payersSwap map[common.Address]*big.Int) (*TransactionsByPriceAndNonce, Transactions) {
 	// Initialize a price and received time based heap with the head transactions
 	heads := TxByPriceAndTime{}
 	heads.payersSwap = payersSwap
@@ -720,15 +720,6 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 		from, _ := Sender(signer, accTxs[0])
 		var normalTxs Transactions
 		lastSpecialTx := -1
-		if len(signers) > 0 {
-			if _, ok := signers[from]; ok {
-				for i, tx := range accTxs {
-					if tx.IsSpecialTransaction() {
-						lastSpecialTx = i
-					}
-				}
-			}
-		}
 		if lastSpecialTx >= 0 {
 			for i := 0; i <= lastSpecialTx; i++ {
 				specialTxs = append(specialTxs, accTxs[i])

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -281,7 +281,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		}
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, nil, map[common.Address]*big.Int{})
+	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, map[common.Address]*big.Int{})
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
@@ -392,7 +392,7 @@ func TestTransactionTimeSort(t *testing.T) {
 		groups[addr] = append(groups[addr], tx)
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, nil, map[common.Address]*big.Int{})
+	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, map[common.Address]*big.Int{})
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -352,7 +352,7 @@ func (w *worker) update() {
 					txs[acc] = append(txs[acc], tx)
 				}
 				feeCapacity := state.GetTRC21FeeCapacityFromState(w.current.state)
-				txset, specialTxs := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, nil, feeCapacity)
+				txset, specialTxs := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, feeCapacity)
 
 				tcount := w.current.tcount
 				w.current.commitTransactions(w.mux, feeCapacity, txset, specialTxs, w.chain, w.coinbase, &w.pendingLogsFeed)
@@ -780,9 +780,8 @@ func (w *worker) commitNewWork() {
 			log.Error("[commitNewWork] fail to check if block is epoch switch block when fetching pending transactions", "BlockNum", header.Number, "Hash", header.Hash())
 		}
 		if !isEpochSwitchBlock {
-			var signers map[common.Address]struct{}
 			pending := w.eth.TxPool().Pending(true)
-			txs, specialTxs = types.NewTransactionsByPriceAndNonce(w.current.signer, pending, signers, feeCapacity)
+			txs, specialTxs = types.NewTransactionsByPriceAndNonce(w.current.signer, pending, feeCapacity)
 		}
 	}
 	if atomic.LoadInt32(&w.mining) == 1 {


### PR DESCRIPTION
# Proposed changes

We always pass nil as parameter `signers` to function `NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions, signers map[common.Address]struct{}, payersSwap map[common.Address]*big.Int)`. So we can remove parameter `signers`.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
