### PR TITLE
params: fix type `V2` not equal bug, close XFN-45

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -18,7 +18,9 @@ package params
 
 import (
 	"fmt"
+	"maps"
 	"math/big"
+	"slices"
 	"strings"
 	"sync"
 
@@ -530,22 +532,15 @@ func V2Equal(a, b *V2) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	if a.SwitchEpoch != b.SwitchEpoch || a.SkipV2Validation != b.SkipV2Validation || !configNumEqual(a.SwitchBlock, b.SwitchBlock) || len(a.configIndex) != len(b.configIndex) || len(a.configIndex) != len(a.AllConfigs) || len(b.configIndex) != len(b.AllConfigs) {
-		return false
-	}
-	for i, idx := range a.configIndex {
-		if idx != b.configIndex[i] {
-			return false
-		}
-		if !V2ConfigEqual(a.AllConfigs[idx], b.AllConfigs[idx]) {
-			return false
-		}
-	}
-	return true
+
+	return a.SwitchEpoch == b.SwitchEpoch && configNumEqual(a.SwitchBlock, b.SwitchBlock) && slices.Equal(a.configIndex, b.configIndex) && maps.EqualFunc(a.AllConfigs, b.AllConfigs, V2ConfigEqual)
 }
 
 func V2ConfigEqual(a, b *V2Config) bool {
-	return a != nil && b != nil && *a == *b
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 func (c *XDPoSConfig) String() string {


### PR DESCRIPTION
# Proposed changes

This PR fixes a bug in function `V2Equal()` which was introduced in #1638. This bug cause:

```text
Rewinding chain to upgrade configuration err="mismatching XDPoS not equal in database (have 80370000, want 80370000, rewindto 80369999)"
```

during node starting.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
