### PR TITLE
eth, internal/ethapi: remove order tx pool API

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -299,16 +299,6 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	return b.eth.txPool.AddLocal(signedTx)
 }
 
-// SendOrderTx send order via backend
-func (b *EthAPIBackend) SendOrderTx(ctx context.Context, signedTx *types.OrderTransaction) error {
-	return b.eth.orderPool.AddLocal(signedTx)
-}
-
-// SendLendingTx send order via backend
-func (b *EthAPIBackend) SendLendingTx(ctx context.Context, signedTx *types.LendingTransaction) error {
-	return b.eth.lendingPool.AddLocal(signedTx)
-}
-
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {
 	pending := b.eth.txPool.Pending(false)
 	var txs types.Transactions
@@ -341,10 +331,6 @@ func (b *EthAPIBackend) TxPoolContent() (map[common.Address]types.Transactions, 
 
 func (b *EthAPIBackend) TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions) {
 	return b.eth.TxPool().ContentFrom(addr)
-}
-
-func (b *EthAPIBackend) OrderTxPoolContent() (map[common.Address]types.OrderTransactions, map[common.Address]types.OrderTransactions) {
-	return b.eth.OrderPool().Content()
 }
 
 func (b *EthAPIBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
@@ -615,23 +601,6 @@ func (b *EthAPIBackend) GetBlocksHashCache(blockNr uint64) []common.Hash {
 
 func (b *EthAPIBackend) AreTwoBlockSamePath(bh1 common.Hash, bh2 common.Hash) bool {
 	return b.eth.blockchain.AreTwoBlockSamePath(bh1, bh2)
-}
-
-// GetOrderNonce get order nonce
-func (b *EthAPIBackend) GetOrderNonce(address common.Hash) (uint64, error) {
-	XDCxService := b.eth.GetXDCX()
-	if XDCxService != nil {
-		author, err := b.Engine().Author(b.CurrentBlock().Header())
-		if err != nil {
-			return 0, err
-		}
-		XDCxState, err := XDCxService.GetTradingState(b.CurrentBlock(), author)
-		if err != nil {
-			return 0, err
-		}
-		return XDCxState.GetNonce(address), nil
-	}
-	return 0, errors.New("cannot find XDCx service")
 }
 
 func (b *EthAPIBackend) XDCxService() *XDCx.XDCX {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1976,22 +1976,6 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	return tx.Hash(), nil
 }
 
-// SubmitTransaction is a helper function that submits tx to txPool and logs a message.
-func submitOrderTransaction(ctx context.Context, b Backend, tx *types.OrderTransaction) (common.Hash, error) {
-	if err := b.SendOrderTx(ctx, tx); err != nil {
-		return common.Hash{}, err
-	}
-	return tx.Hash(), nil
-}
-
-// submitLendingTransaction is a helper function that submits tx to txPool and logs a message.
-func submitLendingTransaction(ctx context.Context, b Backend, tx *types.LendingTransaction) (common.Hash, error) {
-	if err := b.SendLendingTx(ctx, tx); err != nil {
-		return common.Hash{}, err
-	}
-	return tx.Hash(), nil
-}
-
 // SendTransaction creates a transaction for the given argument, sign it and submit it to the
 // transaction pool.
 func (s *TransactionAPI) SendTransaction(ctx context.Context, args TransactionArgs) (common.Hash, error) {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -90,11 +90,6 @@ type Backend interface {
 	TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 
-	// Order Pool Transaction
-	SendOrderTx(ctx context.Context, signedTx *types.OrderTransaction) error
-	OrderTxPoolContent() (map[common.Address]types.OrderTransactions, map[common.Address]types.OrderTransactions)
-	SendLendingTx(ctx context.Context, signedTx *types.LendingTransaction) error
-
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine
 	CurrentBlock() *types.Block
@@ -107,7 +102,6 @@ type Backend interface {
 	GetMasternodesCap(checkpoint uint64) map[common.Address]*big.Int
 	GetBlocksHashCache(blockNr uint64) []common.Hash
 	AreTwoBlockSamePath(newBlock common.Hash, oldBlock common.Hash) bool
-	GetOrderNonce(address common.Hash) (uint64, error)
 
 	// This is copied from filters.Backend
 	// eth/filters needs to be initialized from this backend type, so methods needed by

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -424,10 +424,6 @@ func (b *backendMock) GetMasternodesCap(uint64) map[common.Address]*big.Int {
 	return nil
 }
 
-func (b *backendMock) GetOrderNonce(common.Hash) (uint64, error) {
-	return 0, nil
-}
-
 func (b *backendMock) GetBody(ctx context.Context, hash common.Hash, number rpc.BlockNumber) (*types.Body, error) {
 	return nil, nil
 }
@@ -448,20 +444,8 @@ func (b *backendMock) LendingService() *XDCxlending.Lending {
 	return nil
 }
 
-func (b *backendMock) OrderTxPoolContent() (map[common.Address]types.OrderTransactions, map[common.Address]types.OrderTransactions) {
-	return nil, nil
-}
-
 func (b *backendMock) ProtocolVersion() int {
 	return 0
-}
-
-func (b *backendMock) SendLendingTx(context.Context, *types.LendingTransaction) error {
-	return nil
-}
-
-func (b *backendMock) SendOrderTx(context.Context, *types.OrderTransaction) error {
-	return nil
 }
 
 func (b *backendMock) XDCxService() *XDCx.XDCX {


### PR DESCRIPTION
# Proposed changes

This PR removes API of order tx pool:

- SendOrderTx
- OrderTxPoolContent
- SendLendingTx
- GetOrderNonce

These APIs are not used anymore.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
