### PR TITLE
core/state: get rid of field pointer in journal #30361

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -144,7 +144,7 @@ func (s *stateObject) markSelfdestructed() {
 
 func (s *stateObject) touch() {
 	s.db.journal.append(touchChange{
-		account: &s.address,
+		account: s.address,
 	})
 	if s.address == ripemd {
 		// Explicitly put it in the dirty-cache, which is otherwise generated from
@@ -230,7 +230,7 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 	}
 	// New value is different, update and journal the change
 	s.db.journal.append(storageChange{
-		account:  &s.address,
+		account:  s.address,
 		key:      key,
 		prevalue: prev,
 	})
@@ -367,7 +367,7 @@ func (s *stateObject) SubBalance(amount *big.Int, reason tracing.BalanceChangeRe
 
 func (s *stateObject) SetBalance(amount *big.Int, reason tracing.BalanceChangeReason) {
 	s.db.journal.append(balanceChange{
-		account: &s.address,
+		account: s.address,
 		prev:    new(big.Int).Set(s.data.Balance),
 	})
 	if s.db.logger != nil && s.db.logger.OnBalanceChange != nil {
@@ -438,14 +438,13 @@ func (s *stateObject) CodeSize(db Database) int {
 }
 
 func (s *stateObject) SetCode(codeHash common.Hash, code []byte) {
-	prevcode := s.Code(s.db.db)
+	prevCode := s.Code(s.db.db)
 	s.db.journal.append(codeChange{
-		account:  &s.address,
-		prevhash: s.CodeHash(),
-		prevcode: prevcode,
+		account:  s.address,
+		prevCode: prevCode,
 	})
 	if s.db.logger != nil && s.db.logger.OnCodeChange != nil {
-		s.db.logger.OnCodeChange(s.address, common.BytesToHash(s.CodeHash()), prevcode, codeHash, code)
+		s.db.logger.OnCodeChange(s.address, common.BytesToHash(s.CodeHash()), prevCode, codeHash, code)
 	}
 	s.setCode(codeHash, code)
 }
@@ -458,7 +457,7 @@ func (s *stateObject) setCode(codeHash common.Hash, code []byte) {
 
 func (s *stateObject) SetNonce(nonce uint64) {
 	s.db.journal.append(nonceChange{
-		account: &s.address,
+		account: s.address,
 		prev:    s.data.Nonce,
 	})
 	if s.db.logger != nil && s.db.logger.OnNonceChange != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -449,7 +449,7 @@ func (s *StateDB) SelfDestruct(addr common.Address) {
 		n    = new(big.Int)
 	)
 	s.journal.append(selfDestructChange{
-		account:     &addr,
+		account:     addr,
 		prev:        stateObject.selfDestructed,
 		prevbalance: prev,
 	})
@@ -480,7 +480,7 @@ func (s *StateDB) SetTransientState(addr common.Address, key, value common.Hash)
 		return
 	}
 	s.journal.append(transientStorageChange{
-		account:  &addr,
+		account:  addr,
 		key:      key,
 		prevalue: prev,
 	})
@@ -590,13 +590,13 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 	prev = s.getDeletedStateObject(addr) // Note, prev might have been deleted, we need that!
 	newobj = newObject(s, addr, types.StateAccount{})
 	if prev == nil {
-		s.journal.append(createObjectChange{account: &addr})
+		s.journal.append(createObjectChange{account: addr})
 	} else {
 		_, prevdestruct := s.stateObjectsDestruct[prev.address]
 		if !prevdestruct {
 			s.stateObjectsDestruct[prev.address] = struct{}{}
 		}
-		s.journal.append(resetObjectChange{account: &addr, prev: prev, prevdestruct: prevdestruct})
+		s.journal.append(resetObjectChange{account: addr, prev: prev, prevdestruct: prevdestruct})
 	}
 
 	newobj.created = true
@@ -970,7 +970,7 @@ func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, d
 // AddAddressToAccessList adds the given address to the access list
 func (s *StateDB) AddAddressToAccessList(addr common.Address) {
 	if s.accessList.AddAddress(addr) {
-		s.journal.append(accessListAddAccountChange{&addr})
+		s.journal.append(accessListAddAccountChange{addr})
 	}
 }
 
@@ -982,12 +982,12 @@ func (s *StateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
 		// scope of 'address' without having the 'address' become already added
 		// to the access list (via call-variant, create, etc).
 		// Better safe than sorry, though
-		s.journal.append(accessListAddAccountChange{&addr})
+		s.journal.append(accessListAddAccountChange{addr})
 	}
 	if slotMod {
 		s.journal.append(accessListAddSlotChange{
-			address: &addr,
-			slot:    &slot,
+			address: addr,
+			slot:    slot,
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

This pull request 

- replaces the field pointer in journal entry with the field itself
- remove field `prevhash` of `codeChange`
 
Ref: #30361

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
