### PR TITLE
trie, XDCx, XDCxlending: not expose db in trie

### DIFF
--- a/XDCx/tradingstate/XDCx_trie.go
+++ b/XDCx/tradingstate/XDCx_trie.go
@@ -19,11 +19,10 @@ package tradingstate
 import (
 	"fmt"
 
-	"github.com/XinFinOrg/XDPoSChain/ethdb"
-	"github.com/XinFinOrg/XDPoSChain/trie"
-
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 // XDCXTrie wraps a trie with key hashing. In a secure trie, all
@@ -146,7 +145,7 @@ func (t *XDCXTrie) GetKey(shaKey []byte) []byte {
 	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
 		return key
 	}
-	return t.trie.Db().Preimage(common.BytesToHash(shaKey))
+	return t.trie.Preimage(common.BytesToHash(shaKey))
 }
 
 // Commit writes all nodes and the secure hash pre-images to the trie's database.
@@ -157,7 +156,7 @@ func (t *XDCXTrie) GetKey(shaKey []byte) []byte {
 func (t *XDCXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
-		t.trie.Db().InsertPreimage(t.secKeyCache)
+		t.trie.InsertPreimage(t.secKeyCache)
 		t.secKeyCache = make(map[string][]byte)
 	}
 	// Commit the trie to its intermediate node database
@@ -169,7 +168,7 @@ func (t *XDCXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
 		return common.Hash{}, err
 	}
 	if nodes != nil {
-		if err := t.trie.Db().Update(trie.NewWithNodeSet(nodes)); err != nil {
+		if err := t.trie.UpdateDb(trie.NewWithNodeSet(nodes)); err != nil {
 			return common.Hash{}, err
 		}
 	}

--- a/XDCxlending/lendingstate/XDCx_trie.go
+++ b/XDCxlending/lendingstate/XDCx_trie.go
@@ -19,11 +19,10 @@ package lendingstate
 import (
 	"fmt"
 
-	"github.com/XinFinOrg/XDPoSChain/ethdb"
-	"github.com/XinFinOrg/XDPoSChain/trie"
-
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 // XDCXTrie wraps a trie with key hashing. In a secure trie, all
@@ -142,7 +141,7 @@ func (t *XDCXTrie) GetKey(shaKey []byte) []byte {
 	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
 		return key
 	}
-	return t.trie.Db().Preimage(common.BytesToHash(shaKey))
+	return t.trie.Preimage(common.BytesToHash(shaKey))
 }
 
 // Commit writes all nodes and the secure hash pre-images to the trie's database.
@@ -153,7 +152,7 @@ func (t *XDCXTrie) GetKey(shaKey []byte) []byte {
 func (t *XDCXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
-		t.trie.Db().InsertPreimage(t.secKeyCache)
+		t.trie.InsertPreimage(t.secKeyCache)
 		t.secKeyCache = make(map[string][]byte)
 	}
 	// Commit the trie to its intermediate node database
@@ -165,7 +164,7 @@ func (t *XDCXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
 		return common.Hash{}, err
 	}
 	if nodes != nil {
-		if err := t.trie.Db().Update(trie.NewWithNodeSet(nodes)); err != nil {
+		if err := t.trie.UpdateDb(trie.NewWithNodeSet(nodes)); err != nil {
 			return common.Hash{}, err
 		}
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -298,21 +298,23 @@ func NewDatabaseWithConfig(diskdb ethdb.KeyValueStore, config *Config) *Database
 	return db
 }
 
-// Preimage retrieves a cached trie Node pre-image from memory. If it cannot be
+// preimage retrieves a cached trie Node pre-image from memory. If it cannot be
 // found cached, the method queries the persistent database for the content.
-func (db *Database) Preimage(hash common.Hash) []byte {
+// NOTE: preimage is only used by XDCx and XDCxlending
+func (db *Database) preimage(hash common.Hash) []byte {
 	if db.preimages == nil {
 		return nil
 	}
 	return db.preimages.preimage(hash)
 }
 
-func (db *Database) InsertPreimage(secKeyCache map[string][]byte) {
+// NOTE: insertPreimage is only used by XDCx and XDCxlending
+func (db *Database) insertPreimage(secKeyCache map[string][]byte) {
 	if db.preimages == nil {
 		return
 	}
 
-	preimages := make(map[common.Hash][]byte)
+	preimages := make(map[common.Hash][]byte, len(secKeyCache))
 	for hk, key := range secKeyCache {
 		preimages[common.BytesToHash([]byte(hk))] = key
 	}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -73,8 +73,28 @@ func (t *Trie) newFlag() nodeFlag {
 	return nodeFlag{dirty: true}
 }
 
-func (t *Trie) Db() *Database {
-	return t.db
+// NOTE: Preimage is only used by XDCx and XDCxlending
+func (t *Trie) Preimage(hash common.Hash) []byte {
+	if t.db == nil {
+		return nil
+	}
+	return t.db.preimage(hash)
+}
+
+// NOTE: InsertPreimage is only used by XDCx and XDCxlending
+func (t *Trie) InsertPreimage(secKeyCache map[string][]byte) {
+	if t.db == nil {
+		return
+	}
+	t.db.insertPreimage(secKeyCache)
+}
+
+// NOTE: UpdateDb is only used by XDCx and XDCxlending
+func (t *Trie) UpdateDb(nodes *MergedNodeSet) error {
+	if t.db == nil {
+		return errors.New("database is nil in trie")
+	}
+	return t.db.Update(nodes)
 }
 
 // Copy returns a copy of Trie.


### PR DESCRIPTION
# Proposed changes

This PR removes the function `Trie.Db()`, so we will not expose `db` field by pointer.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
