### PR TITLE
common: fix size comparison in StorageSize #33105

### DIFF
--- a/common/size.go
+++ b/common/size.go
@@ -26,13 +26,13 @@ type StorageSize float64
 
 // String implements the stringer interface.
 func (s StorageSize) String() string {
-	if s > 1099511627776 {
+	if s >= 1099511627776 {
 		return fmt.Sprintf("%.2f TiB", s/1099511627776)
-	} else if s > 1073741824 {
+	} else if s >= 1073741824 {
 		return fmt.Sprintf("%.2f GiB", s/1073741824)
-	} else if s > 1048576 {
+	} else if s >= 1048576 {
 		return fmt.Sprintf("%.2f MiB", s/1048576)
-	} else if s > 1024 {
+	} else if s >= 1024 {
 		return fmt.Sprintf("%.2f KiB", s/1024)
 	} else {
 		return fmt.Sprintf("%.2f B", s)
@@ -42,13 +42,13 @@ func (s StorageSize) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (s StorageSize) TerminalString() string {
-	if s > 1099511627776 {
+	if s >= 1099511627776 {
 		return fmt.Sprintf("%.2fTiB", s/1099511627776)
-	} else if s > 1073741824 {
+	} else if s >= 1073741824 {
 		return fmt.Sprintf("%.2fGiB", s/1073741824)
-	} else if s > 1048576 {
+	} else if s >= 1048576 {
 		return fmt.Sprintf("%.2fMiB", s/1048576)
-	} else if s > 1024 {
+	} else if s >= 1024 {
 		return fmt.Sprintf("%.2fKiB", s/1024)
 	} else {
 		return fmt.Sprintf("%.2fB", s)


### PR DESCRIPTION
# Proposed changes

Exactly 1024 bytes gets displayed as "1024.00 B" instead of "1.00 KiB" because we're using > instead of >=. Fixed both String() and erminalString() so boundary values show up in the right unit.

Ref: #33105

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
