### PR TITLE
core/state: move state log mechanism to a separate layer #30569 #30732

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -43,7 +43,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/bloombits"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
-	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
@@ -738,7 +737,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 
 	// Set infinite balance to the fake caller account.
 	from := stateDB.GetOrNewStateObject(call.From)
-	from.SetBalance(math.MaxBig256, tracing.BalanceChangeUnspecified)
+	from.SetBalance(math.MaxBig256)
 
 	// Execute the call.
 	msg := &core.Message{

--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -30,6 +30,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus/clique"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -276,7 +277,7 @@ func (x *XDPoS) Prepare(chain consensus.ChainReader, header *types.Header) error
 
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given, and returns the final block.
-func (x *XDPoS) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+func (x *XDPoS) Finalize(chain consensus.ChainReader, header *types.Header, state vm.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	switch x.config.BlockConsensusVersion(header.Number) {
 	case params.ConsensusEngineVersion2:
 		return x.EngineV2.Finalize(chain, header, state, parentState, txs, uncles, receipts)

--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus/misc/eip1559"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -53,7 +54,7 @@ type XDPoS_v1 struct {
 	signFn clique.SignerFn // Signer function to authorize hashes with
 	lock   sync.RWMutex    // Protects the signer fields
 
-	HookReward            func(chain consensus.ChainReader, state *state.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error)
+	HookReward            func(chain consensus.ChainReader, state vm.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error)
 	HookPenalty           func(chain consensus.ChainReader, blockNumberEpoc uint64) ([]common.Address, error)
 	HookPenaltyTIPSigning func(chain consensus.ChainReader, header *types.Header, candidate []common.Address) ([]common.Address, error)
 	HookValidator         func(header *types.Header, signers []common.Address) ([]byte, error)
@@ -823,7 +824,7 @@ func (x *XDPoS_v1) UpdateMasternodes(chain consensus.ChainReader, header *types.
 
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given, and returns the final block.
-func (x *XDPoS_v1) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+func (x *XDPoS_v1) Finalize(chain consensus.ChainReader, header *types.Header, state vm.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// set block reward
 	number := header.Number.Uint64()
 	rCheckpoint := chain.Config().XDPoS.RewardCheckpoint

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus/misc"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -74,7 +75,7 @@ type XDPoS_v2 struct {
 	latestReward         map[string]interface{}
 	latestRewardBlocknum uint64
 
-	HookReward  func(chain consensus.ChainReader, state *state.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error)
+	HookReward  func(chain consensus.ChainReader, state vm.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error)
 	HookPenalty func(chain consensus.ChainReader, number *big.Int, parentHash common.Hash, candidates []common.Address) ([]common.Address, error)
 
 	ForensicsProcessor *Forensics
@@ -410,7 +411,7 @@ func (x *XDPoS_v2) Prepare(chain consensus.ChainReader, header *types.Header) er
 
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given, and returns the final block.
-func (x *XDPoS_v2) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+func (x *XDPoS_v2) Finalize(chain consensus.ChainReader, header *types.Header, state vm.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// set block reward
 
 	isEpochSwitch, _, err := x.IsEpochSwitch(header)

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -34,6 +34,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus/misc"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -584,7 +585,7 @@ func (c *Clique) Prepare(chain consensus.ChainReader, header *types.Header) erro
 
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given, and returns the final block.
-func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, state vm.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// No block rewards in PoA, so the state remains as is and uncles are dropped
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	header.UncleHash = types.CalcUncleHash(nil)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -23,6 +23,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
 )
@@ -83,7 +84,7 @@ type Engine interface {
 	// and assembles the final block.
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
-	Finalize(chain ChainReader, header *types.Header, state *state.StateDB, parentState *state.StateDB, txs []*types.Transaction,
+	Finalize(chain ChainReader, header *types.Header, state vm.StateDB, parentState *state.StateDB, txs []*types.Transaction,
 		uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error)
 
 	// Seal generates a new block for the given input block with the local miner's

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -29,6 +29,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 	mapset "github.com/deckarep/golang-set/v2"
@@ -433,7 +434,7 @@ func (ethash *Ethash) Prepare(chain consensus.ChainReader, header *types.Header)
 
 // Finalize implements consensus.Engine, accumulating the block and uncle rewards,
 // setting the final state and assembling the block.
-func (ethash *Ethash) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+func (ethash *Ethash) Finalize(chain consensus.ChainReader, header *types.Header, state vm.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
@@ -451,7 +452,7 @@ var (
 // AccumulateRewards credits the coinbase of the given block with the mining
 // reward. The total reward consists of the static block reward and rewards for
 // included uncles. The coinbase of each uncle block is also rewarded.
-func accumulateRewards(config *params.ChainConfig, stateDB *state.StateDB, header *types.Header, uncles []*types.Header) {
+func accumulateRewards(config *params.ChainConfig, stateDB vm.StateDB, header *types.Header, uncles []*types.Header) {
 	// Select the correct block reward based on chain progression
 	blockReward := FrontierBlockReward
 	if config.IsByzantium(header.Number) {

--- a/consensus/misc/dao.go
+++ b/consensus/misc/dao.go
@@ -21,9 +21,9 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/params"
 )
 
@@ -73,7 +73,7 @@ func VerifyDAOHeaderExtraData(config *params.ChainConfig, header *types.Header) 
 // ApplyDAOHardFork modifies the state database according to the DAO hard-fork
 // rules, transferring all balances of a set of DAO accounts to a single refund
 // contract.
-func ApplyDAOHardFork(statedb *state.StateDB) {
+func ApplyDAOHardFork(statedb vm.StateDB) {
 	// Retrieve the contract to refund balances into
 	if !statedb.Exist(params.DAORefundContract) {
 		statedb.CreateAccount(params.DAORefundContract)
@@ -81,7 +81,8 @@ func ApplyDAOHardFork(statedb *state.StateDB) {
 
 	// Move every DAO account and extra-balance account funds into the refund contract
 	for _, addr := range params.DAODrainList() {
-		statedb.AddBalance(params.DAORefundContract, statedb.GetBalance(addr), tracing.BalanceIncreaseDaoContract)
-		statedb.SetBalance(addr, new(big.Int), tracing.BalanceDecreaseDaoAccount)
+		balance := statedb.GetBalance(addr)
+		statedb.AddBalance(params.DAORefundContract, balance, tracing.BalanceIncreaseDaoContract)
+		statedb.SubBalance(addr, balance, tracing.BalanceDecreaseDaoAccount)
 	}
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1552,7 +1552,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		if err != nil {
 			return it.index, events, coalescedLogs, err
 		}
-		statedb.SetLogger(bc.logger)
 
 		// If we have a followup block, run that against the current state to pre-cache
 		// transactions and probabilistically some of the account/storage trie nodes.

--- a/core/evm.go
+++ b/core/evm.go
@@ -117,7 +117,7 @@ func GetHashFn(ref *types.Header, chain ChainContext) func(n uint64) common.Hash
 	}
 }
 
-// CanTransfer checks wether there are enough funds in the address' account to make a transfer.
+// CanTransfer checks whether there are enough funds in the address' account to make a transfer.
 // This does not take the necessary gas in to account to make the transfer valid.
 func CanTransfer(db vm.StateDB, addr common.Address, amount *big.Int) bool {
 	return db.GetBalance(addr).Cmp(amount) >= 0

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
@@ -49,11 +48,11 @@ func TestDump(t *testing.T) {
 
 	// generate a few entries
 	obj1 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x01}))
-	obj1.AddBalance(big.NewInt(22), tracing.BalanceChangeUnspecified)
+	obj1.AddBalance(big.NewInt(22))
 	obj2 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x01, 0x02}))
 	obj2.SetCode(crypto.Keccak256Hash([]byte{3, 3, 3, 3, 3, 3, 3}), []byte{3, 3, 3, 3, 3, 3, 3})
 	obj3 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x02}))
-	obj3.SetBalance(big.NewInt(44), tracing.BalanceChangeUnspecified)
+	obj3.SetBalance(big.NewInt(44))
 
 	// write some of them to the trie
 	s.state.updateStateObject(obj1)
@@ -101,13 +100,13 @@ func TestIterativeDump(t *testing.T) {
 
 	// generate a few entries
 	obj1 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x01}))
-	obj1.AddBalance(big.NewInt(22), tracing.BalanceChangeUnspecified)
+	obj1.AddBalance(big.NewInt(22))
 	obj2 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x01, 0x02}))
 	obj2.SetCode(crypto.Keccak256Hash([]byte{3, 3, 3, 3, 3, 3, 3}), []byte{3, 3, 3, 3, 3, 3, 3})
 	obj3 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x02}))
-	obj3.SetBalance(big.NewInt(44), tracing.BalanceChangeUnspecified)
+	obj3.SetBalance(big.NewInt(44))
 	obj4 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x00}))
-	obj4.AddBalance(big.NewInt(1337), tracing.BalanceChangeUnspecified)
+	obj4.AddBalance(big.NewInt(1337))
 
 	// write some of them to the trie
 	s.state.updateStateObject(obj1)
@@ -203,7 +202,7 @@ func TestSnapshot2(t *testing.T) {
 
 	// db, trie are already non-empty values
 	so0 := state.getStateObject(stateobjaddr0)
-	so0.SetBalance(big.NewInt(42), tracing.BalanceChangeUnspecified)
+	so0.SetBalance(big.NewInt(42))
 	so0.SetNonce(43)
 	so0.SetCode(crypto.Keccak256Hash([]byte{'c', 'a', 'f', 'e'}), []byte{'c', 'a', 'f', 'e'})
 	so0.selfDestructed = false
@@ -215,7 +214,7 @@ func TestSnapshot2(t *testing.T) {
 
 	// and one with deleted == true
 	so1 := state.getStateObject(stateobjaddr1)
-	so1.SetBalance(big.NewInt(52), tracing.BalanceChangeUnspecified)
+	so1.SetBalance(big.NewInt(52))
 	so1.SetNonce(53)
 	so1.SetCode(crypto.Keccak256Hash([]byte{'c', 'a', 'f', 'e', '2'}), []byte{'c', 'a', 'f', 'e', '2'})
 	so1.selfDestructed = true

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -1,0 +1,277 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"math/big"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/tracing"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+// hookedStateDB represents a statedb which emits calls to tracing-hooks
+// on state operations.
+type hookedStateDB struct {
+	inner *StateDB
+	hooks *tracing.Hooks
+}
+
+// NewHookedState wraps the given stateDb with the given hooks
+func NewHookedState(stateDb *StateDB, hooks *tracing.Hooks) *hookedStateDB {
+	s := &hookedStateDB{stateDb, hooks}
+	if s.hooks == nil {
+		s.hooks = new(tracing.Hooks)
+	}
+	return s
+}
+
+func (s *hookedStateDB) CreateAccount(addr common.Address) {
+	s.inner.CreateAccount(addr)
+}
+
+func (s *hookedStateDB) CreateContract(addr common.Address) {
+	s.inner.CreateContract(addr)
+}
+
+func (s *hookedStateDB) GetBalance(addr common.Address) *big.Int {
+	return s.inner.GetBalance(addr)
+}
+
+func (s *hookedStateDB) GetNonce(addr common.Address) uint64 {
+	return s.inner.GetNonce(addr)
+}
+
+func (s *hookedStateDB) GetCodeHash(addr common.Address) common.Hash {
+	return s.inner.GetCodeHash(addr)
+}
+
+func (s *hookedStateDB) GetCode(addr common.Address) []byte {
+	return s.inner.GetCode(addr)
+}
+
+func (s *hookedStateDB) GetCodeSize(addr common.Address) int {
+	return s.inner.GetCodeSize(addr)
+}
+
+func (s *hookedStateDB) AddRefund(u uint64) {
+	s.inner.AddRefund(u)
+}
+
+func (s *hookedStateDB) SubRefund(u uint64) {
+	s.inner.SubRefund(u)
+}
+
+func (s *hookedStateDB) GetRefund() uint64 {
+	return s.inner.GetRefund()
+}
+
+func (s *hookedStateDB) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+	return s.inner.GetCommittedState(addr, hash)
+}
+
+func (s *hookedStateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
+	return s.inner.GetState(addr, hash)
+}
+
+func (s *hookedStateDB) GetStorageRoot(addr common.Address) common.Hash {
+	return s.inner.GetStorageRoot(addr)
+}
+
+func (s *hookedStateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	return s.inner.GetTransientState(addr, key)
+}
+
+func (s *hookedStateDB) SetTransientState(addr common.Address, key, value common.Hash) {
+	s.inner.SetTransientState(addr, key, value)
+}
+
+func (s *hookedStateDB) HasSelfDestructed(addr common.Address) bool {
+	return s.inner.HasSelfDestructed(addr)
+}
+
+func (s *hookedStateDB) Exist(addr common.Address) bool {
+	return s.inner.Exist(addr)
+}
+
+func (s *hookedStateDB) Empty(addr common.Address) bool {
+	return s.inner.Empty(addr)
+}
+
+func (s *hookedStateDB) AddressInAccessList(addr common.Address) bool {
+	return s.inner.AddressInAccessList(addr)
+}
+
+func (s *hookedStateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	return s.inner.SlotInAccessList(addr, slot)
+}
+
+func (s *hookedStateDB) AddAddressToAccessList(addr common.Address) {
+	s.inner.AddAddressToAccessList(addr)
+}
+
+func (s *hookedStateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	s.inner.AddSlotToAccessList(addr, slot)
+}
+
+func (s *hookedStateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	s.inner.Prepare(rules, sender, coinbase, dest, precompiles, txAccesses)
+}
+
+func (s *hookedStateDB) RevertToSnapshot(i int) {
+	s.inner.RevertToSnapshot(i)
+}
+
+func (s *hookedStateDB) Snapshot() int {
+	return s.inner.Snapshot()
+}
+
+func (s *hookedStateDB) AddPreimage(hash common.Hash, bytes []byte) {
+	s.inner.AddPreimage(hash, bytes)
+}
+
+func (s *hookedStateDB) SubBalance(addr common.Address, amount *big.Int, reason tracing.BalanceChangeReason) *big.Int {
+	prev := s.inner.SubBalance(addr, amount, reason)
+	if s.hooks.OnBalanceChange != nil && amount.Sign() != 0 {
+		newBalance := new(big.Int).Sub(prev, amount)
+		s.hooks.OnBalanceChange(addr, prev, newBalance, reason)
+	}
+	return prev
+}
+
+func (s *hookedStateDB) AddBalance(addr common.Address, amount *big.Int, reason tracing.BalanceChangeReason) *big.Int {
+	prev := s.inner.AddBalance(addr, amount, reason)
+	if s.hooks.OnBalanceChange != nil && amount.Sign() != 0 {
+		newBalance := new(big.Int).Add(prev, amount)
+		s.hooks.OnBalanceChange(addr, prev, newBalance, reason)
+	}
+	return prev
+}
+
+func (s *hookedStateDB) SetNonce(address common.Address, nonce uint64) {
+	prev := s.inner.GetNonce(address)
+	s.inner.SetNonce(address, nonce)
+	if s.hooks.OnNonceChange != nil {
+		s.hooks.OnNonceChange(address, prev, nonce)
+	}
+}
+
+func (s *hookedStateDB) SetCode(address common.Address, code []byte) {
+	prevCode := s.inner.GetCode(address)
+	s.inner.SetCode(address, code)
+	if s.hooks.OnCodeChange != nil {
+		prevHash := crypto.Keccak256Hash(prevCode)
+		codeHash := crypto.Keccak256Hash(code)
+
+		// Invoke the hooks only if the contract code is changed
+		if prevHash != codeHash {
+			s.hooks.OnCodeChange(address, prevHash, prevCode, codeHash, code)
+		}
+	}
+}
+
+func (s *hookedStateDB) SetState(address common.Address, key common.Hash, value common.Hash) common.Hash {
+	prev := s.inner.SetState(address, key, value)
+	if s.hooks.OnStorageChange != nil && prev != value {
+		s.hooks.OnStorageChange(address, key, prev, value)
+	}
+	return prev
+}
+
+func (s *hookedStateDB) SelfDestruct(address common.Address) *big.Int {
+	prev := s.inner.SelfDestruct(address)
+	if s.hooks.OnBalanceChange != nil {
+		s.hooks.OnBalanceChange(address, prev, new(big.Int), tracing.BalanceDecreaseSelfdestruct)
+	}
+	return prev
+}
+
+func (s *hookedStateDB) SelfDestruct6780(address common.Address) (*big.Int, bool) {
+	prev, changed := s.inner.SelfDestruct6780(address)
+	if changed {
+		if s.hooks.OnBalanceChange != nil {
+			s.hooks.OnBalanceChange(address, prev, new(big.Int), tracing.BalanceDecreaseSelfdestruct)
+		}
+	}
+	return prev, changed
+}
+
+func (s *hookedStateDB) AddLog(log *types.Log) {
+	// The inner will modify the log (add fields), so invoke that first
+	s.inner.AddLog(log)
+	if s.hooks.OnLog != nil {
+		s.hooks.OnLog(log)
+	}
+}
+
+func (s *hookedStateDB) Finalise(deleteEmptyObjects bool) {
+	defer s.inner.Finalise(deleteEmptyObjects)
+	if s.hooks.OnBalanceChange == nil {
+		return
+	}
+	for addr := range s.inner.journal.dirties {
+		obj := s.inner.stateObjects[addr]
+		if obj != nil && obj.selfDestructed {
+			// If ether was sent to account post-selfdestruct it is burnt.
+			if bal := obj.Balance(); bal.Sign() != 0 {
+				s.hooks.OnBalanceChange(addr, bal, new(big.Int), tracing.BalanceDecreaseSelfdestructBurn)
+			}
+		}
+	}
+}
+
+func (s *hookedStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	return s.inner.IntermediateRoot(deleteEmptyObjects)
+}
+
+func (s *hookedStateDB) UpdateTRC21Fee(newBalance map[common.Address]*big.Int, totalFeeUsed *big.Int) {
+	s.inner.UpdateTRC21Fee(newBalance, totalFeeUsed)
+}
+
+func (s *hookedStateDB) PutMintedRecordOnsetBlock(value common.Hash) {
+	s.inner.PutMintedRecordOnsetBlock(value)
+}
+
+func (s *hookedStateDB) PutMintedRecordOnsetEpoch(value common.Hash) {
+	s.inner.PutMintedRecordOnsetEpoch(value)
+}
+
+func (s *hookedStateDB) GetPostBurned(epoch uint64) common.Hash {
+	return s.inner.GetPostBurned(epoch)
+}
+
+func (s *hookedStateDB) PutPostBurned(epoch uint64, value common.Hash) {
+	s.inner.PutPostBurned(epoch, value)
+}
+
+func (s *hookedStateDB) GetPostMinted(epoch uint64) common.Hash {
+	return s.inner.GetPostMinted(epoch)
+}
+
+func (s *hookedStateDB) PutPostMinted(epoch uint64, value common.Hash) {
+	s.inner.PutPostMinted(epoch, value)
+}
+
+func (s *hookedStateDB) PutPostRewardBlock(epoch uint64, value common.Hash) {
+	s.inner.PutPostRewardBlock(epoch, value)
+}
+
+func (s *hookedStateDB) IncrementMintedRecordNonce() {
+	s.inner.IncrementMintedRecordNonce()
+}

--- a/core/state/statedb_hooked_test.go
+++ b/core/state/statedb_hooked_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/tracing"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+)
+
+// This method tests that the 'burn' from sending-to-selfdestructed accounts
+// is accounted for.
+// (There is also a higher-level test in eth/tracers: TestSupplySelfDestruct )
+func TestBurn(t *testing.T) {
+	// Note: burn can happen even after EIP-6780, if within one single transaction,
+	// the following occur:
+	// 1. contract B creates contract A
+	// 2. contract A is destructed
+	// 3. contract B sends ether to A
+
+	var burned = new(big.Int)
+	s, _ := New(types.EmptyRootHash, NewDatabaseForTesting())
+	hooked := NewHookedState(s, &tracing.Hooks{
+		OnBalanceChange: func(addr common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+			if reason == tracing.BalanceDecreaseSelfdestructBurn {
+				burned.Add(burned, prev)
+			}
+		},
+	})
+	createAndDestroy := func(addr common.Address) {
+		hooked.AddBalance(addr, big.NewInt(100), tracing.BalanceChangeUnspecified)
+		hooked.CreateContract(addr)
+		hooked.SelfDestruct(addr)
+		// sanity-check that balance is now 0
+		if have, want := hooked.GetBalance(addr), new(big.Int); have.Cmp(want) != 0 {
+			t.Fatalf("post-destruct balance wrong: have %v want %v", have, want)
+		}
+	}
+	addA := common.Address{0xaa}
+	addB := common.Address{0xbb}
+	addC := common.Address{0xcc}
+
+	// Tx 1: create and destroy address A and B in one tx
+	createAndDestroy(addA)
+	createAndDestroy(addB)
+	hooked.AddBalance(addA, big.NewInt(200), tracing.BalanceChangeUnspecified)
+	hooked.AddBalance(addB, big.NewInt(200), tracing.BalanceChangeUnspecified)
+	hooked.Finalise(true)
+
+	// Tx 2: create and destroy address C, then commit
+	createAndDestroy(addC)
+	hooked.AddBalance(addC, big.NewInt(200), tracing.BalanceChangeUnspecified)
+	hooked.Finalise(true)
+
+	s.Commit(false)
+	if have, want := burned, big.NewInt(600); have.Cmp(want) != 0 {
+		t.Fatalf("burn-count wrong, have %v want %v", have, want)
+	}
+}
+
+// TestHooks is a basic sanity-check of all hooks
+func TestHooks(t *testing.T) {
+	inner, _ := New(types.EmptyRootHash, NewDatabaseForTesting())
+	inner.SetTxContext(common.Hash{0x11}, 100) // For the log
+	var result []string
+	var wants = []string{
+		"0xaa00000000000000000000000000000000000000.balance: 0->100 (BalanceChangeUnspecified)",
+		"0xaa00000000000000000000000000000000000000.balance: 100->50 (BalanceChangeTransfer)",
+		"0xaa00000000000000000000000000000000000000.nonce: 0->1337",
+		"0xaa00000000000000000000000000000000000000.code:  (0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470) ->0x1325 (0xa12ae05590de0c93a00bc7ac773c2fdb621e44f814985e72194f921c0050f728)",
+		"0xaa00000000000000000000000000000000000000.storage slot 0x0000000000000000000000000000000000000000000000000000000000000001: 0x0000000000000000000000000000000000000000000000000000000000000000 ->0x0000000000000000000000000000000000000000000000000000000000000011",
+		"0xaa00000000000000000000000000000000000000.storage slot 0x0000000000000000000000000000000000000000000000000000000000000001: 0x0000000000000000000000000000000000000000000000000000000000000011 ->0x0000000000000000000000000000000000000000000000000000000000000022",
+		"log 100",
+	}
+	emitF := func(format string, a ...any) {
+		result = append(result, fmt.Sprintf(format, a...))
+	}
+	sdb := NewHookedState(inner, &tracing.Hooks{
+		OnBalanceChange: func(addr common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+			emitF("%v.balance: %v->%v (%v)", addr, prev, new, reason)
+		},
+		OnNonceChange: func(addr common.Address, prev, new uint64) {
+			emitF("%v.nonce: %v->%v", addr, prev, new)
+		},
+		OnCodeChange: func(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte) {
+			emitF("%v.code: %#x (%v) ->%#x (%v)", addr, prevCode, prevCodeHash, code, codeHash)
+		},
+		OnStorageChange: func(addr common.Address, slot common.Hash, prev, new common.Hash) {
+			emitF("%v.storage slot %v: %v ->%v", addr, slot, prev, new)
+		},
+		OnLog: func(log *types.Log) {
+			emitF("log %v", log.TxIndex)
+		},
+	})
+	sdb.AddBalance(common.Address{0xaa}, big.NewInt(100), tracing.BalanceChangeUnspecified)
+	sdb.SubBalance(common.Address{0xaa}, big.NewInt(50), tracing.BalanceChangeTransfer)
+	sdb.SetNonce(common.Address{0xaa}, 1337)
+	sdb.SetCode(common.Address{0xaa}, []byte{0x13, 37})
+	sdb.SetState(common.Address{0xaa}, common.HexToHash("0x01"), common.HexToHash("0x11"))
+	sdb.SetState(common.Address{0xaa}, common.HexToHash("0x01"), common.HexToHash("0x22"))
+	sdb.SetTransientState(common.Address{0xaa}, common.HexToHash("0x02"), common.HexToHash("0x01"))
+	sdb.SetTransientState(common.Address{0xaa}, common.HexToHash("0x02"), common.HexToHash("0x02"))
+	sdb.AddLog(&types.Log{
+		Address: common.Address{0xbb},
+	})
+	for i, want := range wants {
+		if have := result[i]; have != want {
+			t.Fatalf("error event %d\nhave: %v\nwant: %v", i, have, want)
+		}
+	}
+}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
@@ -52,7 +51,7 @@ func makeTestState() (ethdb.Database, Database, common.Hash, []*testAccount) {
 		obj := state.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		acc := &testAccount{address: common.BytesToAddress([]byte{i})}
 
-		obj.AddBalance(big.NewInt(11*int64(i)), tracing.BalanceChangeUnspecified)
+		obj.AddBalance(big.NewInt(11 * int64(i)))
 		acc.balance = big.NewInt(11 * int64(i))
 
 		obj.SetNonce(uint64(42 * i))

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -859,7 +859,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.SubBalance(scope.Contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
-	evm.StateDB.Selfdestruct6780(scope.Contract.Address())
+	evm.StateDB.SelfDestruct6780(scope.Contract.Address())
 	if tracer := evm.Config.Tracer; tracer != nil {
 		if tracer.OnEnter != nil {
 			tracer.OnEnter(evm.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -18,6 +18,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/eth/util"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -255,7 +256,7 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 	}
 
 	// Hook calculates reward for masternodes
-	adaptor.EngineV1.HookReward = func(chain consensus.ChainReader, stateBlock *state.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error) {
+	adaptor.EngineV1.HookReward = func(chain consensus.ChainReader, stateBlock vm.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error) {
 		number := header.Number.Uint64()
 		rCheckpoint := chain.Config().XDPoS.RewardCheckpoint
 		foundationWalletAddr := chain.Config().XDPoS.FoudationWalletAddr

--- a/eth/hooks/engine_v2_hooks.go
+++ b/eth/hooks/engine_v2_hooks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/eth/util"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -265,7 +266,7 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 	}
 
 	// Hook calculates reward for masternodes
-	adaptor.EngineV2.HookReward = func(chain consensus.ChainReader, stateBlock *state.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error) {
+	adaptor.EngineV2.HookReward = func(chain consensus.ChainReader, stateBlock vm.StateDB, parentState *state.StateDB, header *types.Header) (map[string]interface{}, error) {
 		number := header.Number.Uint64()
 		foundationWalletAddr := chain.Config().XDPoS.FoudationWalletAddr
 		if foundationWalletAddr == (common.Address{}) {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -881,7 +881,6 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 	}
 	// The actual TxContext will be created as part of ApplyTransactionWithEVM.
 	vmenv := vm.NewEVM(vmctx, vm.TxContext{GasPrice: message.GasPrice}, statedb, nil, api.backend.ChainConfig(), vm.Config{Tracer: tracer.Hooks, NoBaseFee: true})
-	statedb.SetLogger(tracer.Hooks)
 
 	// Define a meaningful timeout of a single transaction trace
 	if config.Timeout != nil {

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -101,7 +101,6 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 		return fmt.Errorf("failed to create call tracer: %v", err)
 	}
 
-	state.SetLogger(tracer.Hooks)
 	msg, err := core.TransactionToMessage(tx, signer, nil, context.BlockNumber, context.BaseFee)
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction for tracing: %v", err)

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -109,18 +109,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
-			// msg, err := core.TransactionToMessage(tx, signer, nil, context.BlockNumber, context.BaseFee)
-			// if err != nil {
-			// 	t.Fatalf("failed to prepare transaction for tracing: %v", err)
-			// }
-			// evm := vm.NewEVM(context, core.NewEVMTxContext(msg), statedb, nil, test.Genesis.Config, vm.Config{Tracer: tracer})
-			// st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-			// if _, err = st.TransitionDb(common.Address{}); err != nil {
-			// 	t.Fatalf("failed to execute transaction: %v", err)
-			// }
-			// // Retrieve the trace result and compare against the expected.
 
-			state.SetLogger(tracer.Hooks)
 			msg, err := core.TransactionToMessage(tx, signer, nil, context.BlockNumber, context.BaseFee)
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -48,9 +48,11 @@ type dummyStatedb struct {
 	state.StateDB
 }
 
-func (*dummyStatedb) GetRefund() uint64                                       { return 1337 }
-func (*dummyStatedb) GetState(_ common.Address, _ common.Hash) common.Hash    { return common.Hash{} }
-func (*dummyStatedb) SetState(_ common.Address, _ common.Hash, _ common.Hash) {}
+func (*dummyStatedb) GetRefund() uint64                                    { return 1337 }
+func (*dummyStatedb) GetState(_ common.Address, _ common.Hash) common.Hash { return common.Hash{} }
+func (*dummyStatedb) SetState(_ common.Address, _ common.Hash, _ common.Hash) common.Hash {
+	return common.Hash{}
+}
 
 func TestStoreCapture(t *testing.T) {
 	var (

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1292,10 +1292,16 @@ func applyMessage(ctx context.Context, b Backend, args TransactionArgs, state *s
 		evm.SetPrecompiles(precompiles)
 	}
 
-	return applyMessageWithEVM(ctx, evm, msg, state, timeout, gp)
+	res, err := applyMessageWithEVM(ctx, evm, msg, timeout, gp)
+	// If an internal state error occurred, let that have precedence. Otherwise,
+	// a "trie root missing" type of error will masquerade as e.g. "insufficient gas"
+	if err := state.Error(); err != nil {
+		return nil, err
+	}
+	return res, err
 }
 
-func applyMessageWithEVM(ctx context.Context, evm *vm.EVM, msg *core.Message, state *state.StateDB, timeout time.Duration, gp *core.GasPool) (*core.ExecutionResult, error) {
+func applyMessageWithEVM(ctx context.Context, evm *vm.EVM, msg *core.Message, timeout time.Duration, gp *core.GasPool) (*core.ExecutionResult, error) {
 	// Wait for the context to be done and cancel the evm. Even if the
 	// EVM has finished, cancelling may be done (repeatedly)
 	go func() {
@@ -1305,9 +1311,6 @@ func applyMessageWithEVM(ctx context.Context, evm *vm.EVM, msg *core.Message, st
 
 	// Execute the message.
 	result, err := core.ApplyMessage(evm, msg, gp, common.Address{})
-	if err := state.Error(); err != nil {
-		return nil, err
-	}
 
 	// If the timer caused an abort, return an appropriate error message
 	if evm.Cancelled() {

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -177,7 +177,10 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		}
 		evm = vm.NewEVM(blockContext, vm.TxContext{GasPrice: new(big.Int)}, sim.state, nil, sim.chainConfig, *vmConfig)
 	)
-	sim.state.SetLogger(tracer.Hooks())
+	var tracingStateDB = vm.StateDB(sim.state)
+	if hooks := tracer.Hooks(); hooks != nil {
+		tracingStateDB = state.NewHookedState(sim.state, hooks)
+	}
 	// It is possible to override precompiles with EVM bytecode, or
 	// move them to another address.
 	if precompiles != nil {
@@ -195,8 +198,8 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		tracer.reset(tx.Hash(), uint(i))
 		// EoA check is always skipped, even in validation mode.
 		msg := call.ToMessage(sim.b, header.BaseFee, !sim.validate, true)
-		evm.Reset(core.NewEVMTxContext(msg), sim.state)
-		result, err := applyMessageWithEVM(ctx, evm, msg, sim.state, timeout, sim.gp)
+		evm.Reset(core.NewEVMTxContext(msg), tracingStateDB)
+		result, err := applyMessageWithEVM(ctx, evm, msg, timeout, sim.gp)
 		if err != nil {
 			txErr := txValidationError(err)
 			return nil, nil, txErr
@@ -204,7 +207,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		// Update the state with pending changes.
 		var root []byte
 		if sim.chainConfig.IsByzantium(blockContext.BlockNumber) {
-			sim.state.Finalise(true)
+			tracingStateDB.Finalise(true)
 		} else {
 			root = sim.state.IntermediateRoot(sim.chainConfig.IsEIP158(blockContext.BlockNumber)).Bytes()
 		}


### PR DESCRIPTION
# Proposed changes

This PR moves the logging-facilities out of `*state.StateDB`, in to a wrapping struct which implements `vm.StateDB` instead.

Ref: 

- #30569
- #30732

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
