### PR TITLE
common: fix duration comparison in PrettyAge #33064

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -69,7 +69,7 @@ func (t PrettyAge) String() string {
 	result, prec := "", 0
 
 	for _, unit := range ageUnits {
-		if diff > unit.Size {
+		if diff >= unit.Size {
 			result = fmt.Sprintf("%s%d%s", result, diff/unit.Size, unit.Symbol)
 			diff %= unit.Size
 


### PR DESCRIPTION
# Proposed changes

This pull request updates `PrettyAge.String` so that the age formatter now treats exact unit boundaries (like a full day or week) as that unit instead of spilling into smaller components, keeping duration output aligned with human expectations.

Ref: #33064

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
