### PR TITLE
internal/jsre: pass only extra args to setTimeout/setInterval callbacks#32936

### DIFF
--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -189,7 +189,7 @@ loop:
 			if !isFunc {
 				panic(re.vm.ToValue("js error: timer/timeout callback is not a function"))
 			}
-			call(goja.Null(), timer.call.Arguments...)
+			call(goja.Null(), timer.call.Arguments[2:]...)
 
 			_, inreg := registry[timer] // when clearInterval is called from within the callback don't reset it
 			if timer.interval && inreg {


### PR DESCRIPTION
# Proposed changes

Summary: Correct the JS timer callback argument forwarding to match standard JS semantics.
What changed: `In internal/jsre/jsre.go`, the callback is now invoked with only the arguments after the callback and delay.
Why: Previously, the callback received the function and delay as parameters, causing unexpected behavior and logic bugs for consumers.

Ref: #32936

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
