### PR TITLE
eth: use consistent receiver name for downloadTester

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -82,8 +82,8 @@ func newTester() *downloadTester {
 	return tester
 }
 
-func (db *downloadTester) TrieDB() *trie.Database {
-	return db.triedb
+func (dl *downloadTester) TrieDB() *trie.Database {
+	return dl.triedb
 }
 
 // terminate aborts any operations on the embedded downloader and releases all
@@ -342,7 +342,7 @@ func (dl *downloadTester) Config() *params.ChainConfig {
 	return &config
 }
 
-func (bc *downloadTester) InterruptInsert(on bool) {
+func (dl *downloadTester) InterruptInsert(on bool) {
 }
 
 type downloadTesterPeer struct {


### PR DESCRIPTION
# Proposed changes

Use consistent receiver name db for downloadTester

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
