### PR TITLE
all: fix invalid syntax for golangci-lint nolint directive

### DIFF
--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -39,7 +39,7 @@ import (
 func TestSimulatedBackend(t *testing.T) {
 	t.Parallel()
 	var gasLimit uint64 = 8000029
-	key, _ := crypto.GenerateKey() // nolint: gosec
+	key, _ := crypto.GenerateKey() //nolint:gosec
 	auth, _ := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337))
 	genAlloc := make(types.GenesisAlloc)
 	genAlloc[auth.From] = types.Account{Balance: big.NewInt(9223372036854775807)}

--- a/accounts/keystore/passphrase_test.go
+++ b/accounts/keystore/passphrase_test.go
@@ -53,7 +53,7 @@ func TestKeyEncryptDecrypt(t *testing.T) {
 			t.Errorf("test %d: key address mismatch: have %x, want %x", i, key.Address, address)
 		}
 		// Recrypt with a new password and start over
-		password += "new data appended" // nolint: gosec
+		password += "new data appended" //nolint:gosec
 		if keyjson, err = EncryptKey(key, password, veryLightScryptN, veryLightScryptP); err != nil {
 			t.Errorf("test %d: failed to re-encrypt key %v", i, err)
 		}

--- a/crypto/blake2b/blake2b_generic.go
+++ b/crypto/blake2b/blake2b_generic.go
@@ -25,7 +25,7 @@ var precomputed = [10][16]byte{
 	{10, 8, 7, 1, 2, 4, 6, 5, 15, 9, 3, 13, 11, 14, 12, 0},
 }
 
-// nolint:unused
+//nolint:unused
 func hashBlocksGeneric(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte) {
 	var m [16]uint64
 	c0, c1 := c[0], c[1]

--- a/internal/build/gotool.go
+++ b/internal/build/gotool.go
@@ -64,7 +64,7 @@ func (g *GoToolchain) goTool(command string, args ...string) *exec.Cmd {
 	if g.Root == "" {
 		g.Root = runtime.GOROOT()
 	}
-	tool := exec.Command(filepath.Join(g.Root, "bin", "go"), command) // nolint: gosec
+	tool := exec.Command(filepath.Join(g.Root, "bin", "go"), command) //nolint:gosec
 	tool.Args = append(tool.Args, args...)
 	tool.Env = append(tool.Env, "GOROOT="+g.Root)
 

--- a/trie/nodeset.go
+++ b/trie/nodeset.go
@@ -35,18 +35,21 @@ type memoryNode struct {
 // memoryNodeSize is the raw size of a memoryNode data structure without any
 // node data included. It's an approximate size, but should be a lot better
 // than not counting them.
-// nolint:unused
+//
+//nolint:unused
 var memoryNodeSize = int(reflect.TypeOf(memoryNode{}).Size())
 
 // memorySize returns the total memory size used by this node.
-// nolint:unused
+//
+//nolint:unused
 func (n *memoryNode) memorySize(key int) int {
 	return int(n.size) + memoryNodeSize + key
 }
 
 // rlp returns the raw rlp encoded blob of the cached trie node, either directly
 // from the cache, or by regenerating it from the collapsed node.
-// nolint:unused
+//
+//nolint:unused
 func (n *memoryNode) rlp() []byte {
 	if node, ok := n.node.(rawNode); ok {
 		return node
@@ -56,7 +59,8 @@ func (n *memoryNode) rlp() []byte {
 
 // obj returns the decoded and expanded trie node, either directly from the cache,
 // or by regenerating it from the rlp encoded blob.
-// nolint:unused
+//
+//nolint:unused
 func (n *memoryNode) obj() node {
 	if node, ok := n.node.(rawNode); ok {
 		return mustDecodeNode(n.hash[:], node)
@@ -71,14 +75,14 @@ type nodeWithPrev struct {
 }
 
 // unwrap returns the internal memoryNode object.
-// nolint:unused
+//nolint:unused
 func (n *nodeWithPrev) unwrap() *memoryNode {
 	return n.memoryNode
 }
 
 // memorySize returns the total memory size used by this node. It overloads
 // the function in memoryNode by counting the size of previous value as well.
-// nolint: unused
+//nolint: unused
 func (n *nodeWithPrev) memorySize(key int) int {
 	return n.memoryNode.memorySize(key) + len(n.prev)
 }


### PR DESCRIPTION
# Proposed changes

Fix invalid directive syntax for golangci-lint nolint

according to: https://golangci-lint.run/docs/linters/false-positives/#syntax

Invalid syntax:

```text
// nolint
// nolint:xxx
//nolint :xxx
//nolint: xxx
```

Valid syntax:

```text
//nolint:xxx
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
