### PR TITLE
consensus/XDPoS, core/rawdb: stop node if fail to store snapshot

### DIFF
--- a/consensus/XDPoS/engines/engine_v1/snapshot.go
+++ b/consensus/XDPoS/engines/engine_v1/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/consensus/clique"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -62,7 +63,7 @@ func newSnapshot(config *params.XDPoSConfig, sigcache *utils.SigLRU, number uint
 
 // loadSnapshot loads an existing snapshot from the database.
 func loadSnapshot(config *params.XDPoSConfig, sigcache *utils.SigLRU, db ethdb.Database, hash common.Hash) (*SnapshotV1, error) {
-	blob, err := db.Get(append([]byte("XDPoS-"), hash[:]...))
+	blob, err := rawdb.ReadXdposV1Snapshot(db, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func (s *SnapshotV1) store(db ethdb.Database) error {
 	if err != nil {
 		return err
 	}
-	return db.Put(append([]byte("XDPoS-"), s.Hash[:]...), blob)
+	return rawdb.WriteXdposV1Snapshot(db, s.Hash, blob)
 }
 
 // copy creates a deep copy of the SnapshotV1, though not the individual votes.

--- a/consensus/XDPoS/engines/engine_v2/snapshot.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 )
@@ -34,7 +35,7 @@ func newSnapshot(number uint64, hash common.Hash, candidates []common.Address) *
 
 // loadSnapshot loads an existing snapshot from the database.
 func loadSnapshot(db ethdb.Database, hash common.Hash) (*SnapshotV2, error) {
-	blob, err := db.Get(append([]byte("XDPoS-V2-"), hash[:]...))
+	blob, err := rawdb.ReadXdposV2Snapshot(db, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +53,7 @@ func storeSnapshot(s *SnapshotV2, db ethdb.Database) error {
 	if err != nil {
 		return err
 	}
-	return db.Put(append([]byte("XDPoS-V2-"), s.Hash[:]...), blob)
+	return rawdb.WriteXdposV2Snapshot(db, s.Hash, blob)
 }
 
 // retrieves candidates nodes list in map type

--- a/core/rawdb/accessors_xdc.go
+++ b/core/rawdb/accessors_xdc.go
@@ -22,6 +22,40 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/log"
 )
 
+// ReadXdposV1Snapshot retrieves an existing snapshot from the database.
+func ReadXdposV1Snapshot(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
+	data, err := db.Get(xdposV1Key(hash))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// WriteXdposV1Snapshot writes the SnapshotV2 into the database.
+func WriteXdposV1Snapshot(db ethdb.KeyValueWriter, hash common.Hash, blob []byte) error {
+	if err := db.Put(xdposV1Key(hash), blob); err != nil {
+		log.Crit("Failed to store SnapshotV2", "err", err)
+	}
+	return nil
+}
+
+// ReadXdposV2Snapshot retrieves an existing snapshot from the database.
+func ReadXdposV2Snapshot(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
+	data, err := db.Get(xdposV2Key(hash))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// WriteXdposV2Snapshot writes the SnapshotV2 into the database.
+func WriteXdposV2Snapshot(db ethdb.KeyValueWriter, hash common.Hash, blob []byte) error {
+	if err := db.Put(xdposV2Key(hash), blob); err != nil {
+		log.Crit("Failed to store SnapshotV2", "err", err)
+	}
+	return nil
+}
+
 // ReadSectionHead retrieves the last block hash of a processed section
 // from the database.
 func ReadSectionHead(db ethdb.KeyValueReader, section uint64) common.Hash {

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -78,6 +78,10 @@ var (
 	// used by old db, now only used for conversion
 	oldTxMetaSuffix = []byte{0x01}
 
+	// XDPoS snapshot prefix
+	xdposV1Prefix = []byte("XDPoS-")
+	xdposV2Prefix = []byte("XDPoS-V2-")
+
 	sectionHeadKeyPrefix = []byte("shead")
 
 	preimageCounter    = metrics.NewRegisteredCounter("db/preimage/total", nil)
@@ -203,6 +207,16 @@ func accountTrieNodeKey(path []byte) []byte {
 // storageTrieNodeKey = trieNodeStoragePrefix + accountHash + nodePath.
 func storageTrieNodeKey(accountHash common.Hash, path []byte) []byte {
 	return append(append(trieNodeStoragePrefix, accountHash.Bytes()...), path...)
+}
+
+// xdposV1Key = xdposV1Prefix + hash
+func xdposV1Key(hash common.Hash) []byte {
+	return append(xdposV1Prefix, hash.Bytes()...)
+}
+
+// xdposV2Key = xdposV2Prefix + hash
+func xdposV2Key(hash common.Hash) []byte {
+	return append(xdposV2Prefix, hash.Bytes()...)
 }
 
 // sectionHeadKey = sectionHeadKeyPrefix + section (uint64 big endian)


### PR DESCRIPTION
# Proposed changes

This PR stops the node if the snapshot is not stored into database successfully.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
