### PR TITLE
build: fix `make generate` not print changed files

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -318,9 +318,14 @@ func doGenerate() {
 	)
 	pathList := []string{filepath.Join(protocPath, "bin"), protocGenGoPath, os.Getenv("PATH")}
 
+	excludes := []string{"tests/testdata", "build/cache", ".git"}
+	for i := range excludes {
+		excludes[i] = filepath.FromSlash(excludes[i])
+	}
+
 	for _, mod := range goModules {
 		// Compute the origin hashes of all the files
-		hashes, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git"})
+		hashes, err := build.HashFolder(mod, excludes)
 		if err != nil {
 			log.Fatal("Error computing hashes", "err", err)
 		}
@@ -330,7 +335,7 @@ func doGenerate() {
 		c.Dir = mod
 		build.MustRun(c)
 		// Check if generate file hashes have changed
-		generated, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git"})
+		generated, err := build.HashFolder(mod, excludes)
 		if err != nil {
 			log.Fatalf("Error re-computing hashes: %v", err)
 		}

--- a/internal/build/file.go
+++ b/internal/build/file.go
@@ -22,19 +22,19 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 )
 
 // HashFolder iterates all files under the given directory, computing the hash
 // of each.
-func HashFolder(folder string, exlude []string) (map[string][32]byte, error) {
+func HashFolder(folder string, excludes []string) (map[string][32]byte, error) {
 	res := make(map[string][32]byte)
 	err := filepath.WalkDir(folder, func(path string, d os.DirEntry, _ error) error {
-		// Skip anything that's exluded or not a regular file
-		for _, skip := range exlude {
-			if strings.HasPrefix(path, filepath.FromSlash(skip)) {
+		// Skip anything that's excluded or not a regular file
+		if slices.Contains(excludes, path) {
+			if d.IsDir() {
 				return filepath.SkipDir
 			}
+			return nil
 		}
 		if !d.Type().IsRegular() {
 			return nil


### PR DESCRIPTION
# Proposed changes

When I run command ` make generate`, the generated files are updated successfully, but the changed files are not printed as expected. After troubleshooting, this bug is caused by function `HashFolder` in the file `internal/build/file.go`. The reason it that `.git` is an excluded path, but we has the following files in the root directory:

- .gitattributes
- .gitignore

these files has prefix `.git`, this makes the current code returns `filepath.SkipDir` when iterate these files, then `filepath.WalkDir` stops iteration in root directory. 

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
