### PR TITLE
cmd/utils, internal/flags: deprecate flag `XDCx-dbName` and `XDCx.dbName`

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -837,15 +837,6 @@ var (
 		Value:    false,
 		Category: flags.XdcCategory,
 	}
-
-	// XDCX settings
-	XDCXDBNameFlag = &cli.StringFlag{
-		Name:     "XDCx-dbName",
-		Aliases:  []string{"XDCx.dbName"},
-		Usage:    "Database name for XDCX",
-		Value:    "XDCdex",
-		Category: flags.XdcxCategory,
-	}
 )
 
 var (
@@ -1444,14 +1435,13 @@ func SetXDCXConfig(ctx *cli.Context, cfg *XDCx.Config, XDCDataDir string) {
 	if ctx.IsSet(XDCXDataDirFlag.Name) {
 		log.Warn("The flag XDCx-datadir or XDCx.datadir is deprecated, please remove this flag")
 	}
+	if ctx.IsSet(XDCXDBNameFlag.Name) {
+		log.Warn("The flag XDCx-dbName or XDCx.dbName is deprecated, please remove this flag")
+	}
 	// XDCx datadir: XDCDataDir/XDCx
 	cfg.DataDir = filepath.Join(XDCDataDir, "XDCx")
-	log.Info("XDCX datadir", "path", cfg.DataDir)
-	if ctx.IsSet(XDCXDBNameFlag.Name) {
-		cfg.DBName = ctx.String(XDCXDBNameFlag.Name)
-	} else {
-		cfg.DBName = XDCXDBNameFlag.Value
-	}
+	cfg.DBName = "XDCdex"
+	log.Info("Set XDCX config", "DataDir", cfg.DataDir, "DBName", cfg.DBName)
 }
 
 // SetEthConfig applies eth-related command line flags to the config.

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -38,6 +38,7 @@ var DeprecatedFlags = []cli.Flag{
 	LogDebugFlag,
 	MiningEnabledFlag,
 	XDCXDataDirFlag,
+	XDCXDBNameFlag,
 	LightServFlag,
 	LightPeersFlag,
 	Enable0xPrefixFlag,
@@ -84,21 +85,29 @@ var (
 	LightServFlag = &cli.IntFlag{
 		Name:     "light-serv",
 		Aliases:  []string{"lightserv"},
-		Usage:    "Maximum percentage of time allowed for serving LES requests (0-90)",
+		Usage:    "Maximum percentage of time allowed for serving LES requests (0-90) (deprecated)",
 		Value:    ethconfig.Defaults.LightServ,
 		Category: flags.DeprecatedCategory,
 	}
 	LightPeersFlag = &cli.IntFlag{
 		Name:     "light-peers",
 		Aliases:  []string{"lightpeers"},
-		Usage:    "Maximum number of LES client peers",
+		Usage:    "Maximum number of LES client peers (deprecated)",
 		Value:    ethconfig.Defaults.LightPeers,
 		Category: flags.DeprecatedCategory,
 	}
-	// Deprecated Oct 2024
+	// Deprecated July 2025
 	EnablePersonal = &cli.BoolFlag{
 		Name:     "rpc.enabledeprecatedpersonal",
-		Usage:    "This used to enable the 'personal' namespace.",
+		Usage:    "This used to enable the 'personal' namespace (deprecated)",
+		Category: flags.DeprecatedCategory,
+	}
+	// Deprecated November 2025
+	XDCXDBNameFlag = &cli.StringFlag{
+		Name:     "XDCx-dbName",
+		Aliases:  []string{"XDCx.dbName"},
+		Usage:    "Database name for XDCX (deprecated)",
+		Value:    "XDCdex",
 		Category: flags.DeprecatedCategory,
 	}
 	// Deprecated November 2025

--- a/internal/flags/categories.go
+++ b/internal/flags/categories.go
@@ -35,7 +35,6 @@ const (
 	MiscCategory       = "MISC"
 	DeprecatedCategory = "ALIASED (deprecated)"
 	XdcCategory        = "XDC"
-	XdcxCategory       = "XDCx"
 )
 
 func init() {


### PR DESCRIPTION
# Proposed changes

This PR deprecates the flag `XDCx-dbName` and `XDCx.dbName`.

close #1780

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
