### PR TITLE
cmd/utils: deprecate flag enable-0x-prefix

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -831,12 +831,6 @@ var (
 	}
 
 	// XDC settings
-	Enable0xPrefixFlag = &cli.BoolFlag{
-		Name:     "enable-0x-prefix",
-		Usage:    "Address use 0x-prefix (Deprecated: this is on by default, to use xdc prefix use --enable-xdc-prefix)",
-		Value:    true,
-		Category: flags.XdcCategory,
-	}
 	EnableXDCPrefixFlag = &cli.BoolFlag{
 		Name:     "enable-xdc-prefix",
 		Usage:    "Address use xdc-prefix (default = false)",
@@ -1325,7 +1319,10 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 // SetNodeConfig applies node-related command line flags to the config.
 func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
-	flags.CheckExclusive(ctx, Enable0xPrefixFlag, EnableXDCPrefixFlag)
+	if ctx.IsSet(Enable0xPrefixFlag.Name) {
+		log.Warn("The flag enable-0x-prefix is deprecated, please remove this flag")
+		flags.CheckExclusive(ctx, Enable0xPrefixFlag, EnableXDCPrefixFlag)
+	}
 	SetP2PConfig(ctx, &cfg.P2P)
 	setIPC(ctx, cfg)
 	setHTTP(ctx, cfg)

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -40,6 +40,7 @@ var DeprecatedFlags = []cli.Flag{
 	XDCXDataDirFlag,
 	LightServFlag,
 	LightPeersFlag,
+	Enable0xPrefixFlag,
 }
 
 var (
@@ -98,6 +99,13 @@ var (
 	EnablePersonal = &cli.BoolFlag{
 		Name:     "rpc.enabledeprecatedpersonal",
 		Usage:    "This used to enable the 'personal' namespace.",
+		Category: flags.DeprecatedCategory,
+	}
+	// Deprecated November 2025
+	Enable0xPrefixFlag = &cli.BoolFlag{
+		Name:     "enable-0x-prefix",
+		Usage:    "Address use 0x-prefix (Deprecated: this is on by default, to use xdc prefix use --enable-xdc-prefix)",
+		Value:    true,
 		Category: flags.DeprecatedCategory,
 	}
 )


### PR DESCRIPTION
# Proposed changes

Deprecate flag enable-0x-prefix

close #1779

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
