### PR TITLE
all: use 0x-prefix for `Address` type in log

### DIFF
--- a/XDCx/order_processor.go
+++ b/XDCx/order_processor.go
@@ -636,7 +636,7 @@ func (XDCx *XDCX) ProcessCancelOrder(header *types.Header, tradingStateDB *tradi
 	}
 	baseTokenDecimal, err := XDCx.GetTokenDecimal(chain, statedb, order.BaseToken)
 	if err != nil || baseTokenDecimal.Sign() == 0 {
-		log.Debug("Fail to get tokenDecimal ", "Token", order.BaseToken.String(), "err", err)
+		log.Debug("Fail to get tokenDecimal ", "Token", order.BaseToken, "err", err)
 		return err, false
 	}
 	// order: basic order information (includes orderId, orderHash, baseToken, quoteToken) which user send to XDCx to cancel order

--- a/XDCx/tradingstate/orderitem.go
+++ b/XDCx/tradingstate/orderitem.go
@@ -312,7 +312,7 @@ func IsValidRelayer(statedb *state.StateDB, address common.Address) bool {
 	locHashDeposit := common.BigToHash(locBigDeposit)
 	balance := statedb.GetState(common.RelayerRegistrationSMC, locHashDeposit).Big()
 	if balance.Cmp(new(big.Int).Mul(common.BasePrice, common.RelayerLockedFund)) <= 0 {
-		log.Debug("Relayer is not in relayer list", "relayer", address.String(), "balance", balance)
+		log.Debug("Relayer is not in relayer list", "relayer", address, "balance", balance)
 		return false
 	}
 	if IsResignedRelayer(address, statedb) {

--- a/XDCx/tradingstate/relayer_state.go
+++ b/XDCx/tradingstate/relayer_state.go
@@ -134,14 +134,14 @@ func SubRelayerFee(relayer common.Address, fee *big.Int, statedb *state.StateDB)
 	locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locBig, RelayerStructMappingSlot["_deposit"])
 	locHashDeposit := common.BigToHash(locBigDeposit)
 	balance := statedb.GetState(common.RelayerRegistrationSMC, locHashDeposit).Big()
-	log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee BEFORE", "relayer", relayer.String(), "balance", balance)
+	log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee BEFORE", "relayer", relayer, "balance", balance)
 	if balance.Cmp(fee) < 0 {
 		return errors.Errorf("relayer %s isn't enough XDC fee", relayer.String())
 	} else {
 		balance = new(big.Int).Sub(balance, fee)
 		statedb.SetState(common.RelayerRegistrationSMC, locHashDeposit, common.BigToHash(balance))
 		statedb.SubBalance(common.RelayerRegistrationSMC, fee, tracing.BalanceChangeUnspecified)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee AFTER", "relayer", relayer.String(), "balance", balance)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee AFTER", "relayer", relayer, "balance", balance)
 		return nil
 	}
 }
@@ -162,10 +162,10 @@ func AddTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 	// XDC native
 	if token == common.XDCNativeAddressBinary {
 		balance := statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN XDC NATIVE BEFORE", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN XDC NATIVE BEFORE", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "orderValue", value)
 		statedb.AddBalance(addr, value, tracing.BalanceChangeUnspecified)
 		balance = statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD XDC NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD XDC NATIVE BALANCE AFTER", "token", token.String(), "address", addr, "balance", balance, "orderValue", value)
 
 		return nil
 	}
@@ -175,10 +175,10 @@ func AddTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 		slot := TokenMappingSlot["balances"]
 		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
 		balance := statedb.GetState(token, locHash).Big()
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE BEFORE", "token", token, "address", addr, "balance", balance, "orderValue", value)
 		balance = new(big.Int).Add(balance, value)
 		statedb.SetState(token, locHash, common.BigToHash(balance))
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE AFTER", "token", token, "address", addr, "balance", balance, "orderValue", value)
 		return nil
 	} else {
 		return errors.Errorf("token %s isn't exist", token.String())
@@ -189,13 +189,13 @@ func SubTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 	// XDC native
 	if token == common.XDCNativeAddressBinary {
 		balance := statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE BEFORE", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE BEFORE", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "orderValue", value)
 		if balance.Cmp(value) < 0 {
 			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		statedb.SubBalance(addr, value, tracing.BalanceChangeUnspecified)
 		balance = statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE AFTER", "token", token.String(), "address", addr, "balance", balance, "orderValue", value)
 		return nil
 	}
 
@@ -204,13 +204,13 @@ func SubTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 		slot := TokenMappingSlot["balances"]
 		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
 		balance := statedb.GetState(token, locHash).Big()
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE BEFORE", "token", token.String(), "address", addr, "balance", balance, "orderValue", value)
 		if balance.Cmp(value) < 0 {
 			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		balance = new(big.Int).Sub(balance, value)
 		statedb.SetState(token, locHash, common.BigToHash(balance))
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE AFTER", "token", token.String(), "address", addr, "balance", balance, "orderValue", value)
 		return nil
 	} else {
 		return errors.Errorf("token %s isn't exist", token.String())
@@ -230,7 +230,7 @@ func CheckSubTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			return nil, errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		newBalance := new(big.Int).Sub(balance, value)
-		log.Debug("CheckSubTokenBalance settle balance: SUB XDC NATIVE BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckSubTokenBalance settle balance: SUB XDC NATIVE BALANCE ", "token", token, "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
 		return newBalance, nil
 	}
 	// TRC tokens
@@ -247,7 +247,7 @@ func CheckSubTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			return nil, errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		newBalance := new(big.Int).Sub(balance, value)
-		log.Debug("CheckSubTokenBalance settle balance: SUB TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckSubTokenBalance settle balance: SUB TOKEN BALANCE ", "token", token, "address", addr, "balance", balance, "value", value, "newBalance", newBalance)
 		return newBalance, nil
 	} else {
 		return nil, errors.Errorf("token %s isn't exist", token.String())
@@ -264,7 +264,7 @@ func CheckAddTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			balance = statedb.GetBalance(addr)
 		}
 		newBalance := new(big.Int).Add(balance, value)
-		log.Debug("CheckAddTokenBalance settle balance: ADD XDC NATIVE BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckAddTokenBalance settle balance: ADD XDC NATIVE BALANCE ", "token", token, "address", addr, "balance", balance, "value", value, "newBalance", newBalance)
 		return newBalance, nil
 	}
 	// TRC tokens
@@ -278,7 +278,7 @@ func CheckAddTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			balance = statedb.GetState(token, locHash).Big()
 		}
 		newBalance := new(big.Int).Add(balance, value)
-		log.Debug("CheckAddTokenBalance settle balance: ADD TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckAddTokenBalance settle balance: ADD TOKEN BALANCE ", "token", token, "address", addr, "balance", balance, "value", value, "newBalance", newBalance)
 		if common.BigToHash(newBalance).Big().Cmp(newBalance) != 0 {
 			return nil, fmt.Errorf("overflow when try add token balance , max is 2^256 , balance : %v , value : %v", balance, value)
 		} else {
@@ -298,7 +298,7 @@ func CheckSubRelayerFee(relayer common.Address, fee *big.Int, statedb *state.Sta
 		locHashDeposit := common.BigToHash(locBigDeposit)
 		balance = statedb.GetState(common.RelayerRegistrationSMC, locHashDeposit).Big()
 	}
-	log.Debug("CheckSubRelayerFee settle balance: SubRelayerFee ", "relayer", relayer.String(), "balance", balance, "fee", fee)
+	log.Debug("CheckSubRelayerFee settle balance: SubRelayerFee ", "relayer", relayer, "balance", balance, "fee", fee)
 	if balance.Cmp(fee) < 0 {
 		return nil, errors.Errorf("relayer %s isn't enough XDC fee", relayer.String())
 	} else {

--- a/XDCxlending/lendingstate/lendingcontract.go
+++ b/XDCxlending/lendingstate/lendingcontract.go
@@ -57,7 +57,7 @@ func IsValidRelayer(statedb *state.StateDB, coinbase common.Address) bool {
 		balance := statedb.GetState(common.RelayerRegistrationSMC, locHashDeposit).Big()
 		expectedFund := new(big.Int).Mul(common.BasePrice, common.RelayerLockedFund)
 		if balance.Cmp(expectedFund) <= 0 {
-			log.Debug("Relayer is not in relayer list", "relayer", coinbase.String(), "balance", balance, "expected", expectedFund)
+			log.Debug("Relayer is not in relayer list", "relayer", coinbase, "balance", balance, "expected", expectedFund)
 			return false
 		}
 		return true

--- a/XDCxlending/lendingstate/relayer.go
+++ b/XDCxlending/lendingstate/relayer.go
@@ -86,14 +86,14 @@ func SubRelayerFee(relayer common.Address, fee *big.Int, statedb *state.StateDB)
 	locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locBig, RelayerStructMappingSlot["_deposit"])
 	locHashDeposit := common.BigToHash(locBigDeposit)
 	balance := statedb.GetState(common.RelayerRegistrationSMC, locHashDeposit).Big()
-	log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee BEFORE", "relayer", relayer.String(), "balance", balance)
+	log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee BEFORE", "relayer", relayer, "balance", balance)
 	if balance.Cmp(fee) < 0 {
 		return errors.Errorf("relayer %s isn't enough XDC fee", relayer.String())
 	} else {
 		balance = new(big.Int).Sub(balance, fee)
 		statedb.SetState(common.RelayerRegistrationSMC, locHashDeposit, common.BigToHash(balance))
 		statedb.SubBalance(common.RelayerRegistrationSMC, fee, tracing.BalanceChangeUnspecified)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee AFTER", "relayer", relayer.String(), "balance", balance)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SubRelayerFee AFTER", "relayer", relayer, "balance", balance)
 		return nil
 	}
 }
@@ -114,10 +114,10 @@ func AddTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 	// XDC native
 	if token == common.XDCNativeAddressBinary {
 		balance := statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN XDC NATIVE BEFORE", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN XDC NATIVE BEFORE", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "orderValue", value)
 		statedb.AddBalance(addr, value, tracing.BalanceChangeUnspecified)
 		balance = statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD XDC NATIVE BALANCE AFTER", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD XDC NATIVE BALANCE AFTER", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "orderValue", value)
 
 		return nil
 	}
@@ -127,10 +127,10 @@ func AddTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 		slot := TokenMappingSlot["balances"]
 		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
 		balance := statedb.GetState(token, locHash).Big()
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE BEFORE", "token", token, "address", addr, "balance", balance, "orderValue", value)
 		balance = new(big.Int).Add(balance, value)
 		statedb.SetState(token, locHash, common.BigToHash(balance))
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: ADD TOKEN BALANCE AFTER", "token", token, "address", addr, "balance", balance, "orderValue", value)
 		return nil
 	} else {
 		return errors.Errorf("token %s isn't exist", token.String())
@@ -141,13 +141,13 @@ func SubTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 	// XDC native
 	if token == common.XDCNativeAddressBinary {
 		balance := statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE BEFORE", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE BEFORE", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "orderValue", value)
 		if balance.Cmp(value) < 0 {
 			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), common.XDCNativeAddress, balance, value)
 		}
 		statedb.SubBalance(addr, value, tracing.BalanceChangeUnspecified)
 		balance = statedb.GetBalance(addr)
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE AFTER", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB XDC NATIVE BALANCE AFTER", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "orderValue", value)
 
 		return nil
 	}
@@ -157,13 +157,13 @@ func SubTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 		slot := TokenMappingSlot["balances"]
 		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
 		balance := statedb.GetState(token, locHash).Big()
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE BEFORE", "token", token, "address", addr, "balance", balance, "orderValue", value)
 		if balance.Cmp(value) < 0 {
 			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		balance = new(big.Int).Sub(balance, value)
 		statedb.SetState(token, locHash, common.BigToHash(balance))
-		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		log.Debug("ApplyXDCXMatchedTransaction settle balance: SUB TOKEN BALANCE AFTER", "token", token, "address", addr, "balance", balance, "orderValue", value)
 		return nil
 	} else {
 		return errors.Errorf("token %s isn't exist", token.String())
@@ -183,7 +183,7 @@ func CheckSubTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			return nil, errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), common.XDCNativeAddress, balance, value)
 		}
 		newBalance := new(big.Int).Sub(balance, value)
-		log.Debug("CheckSubTokenBalance settle balance: SUB XDC NATIVE BALANCE ", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckSubTokenBalance settle balance: SUB XDC NATIVE BALANCE ", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "value", value, "newBalance", newBalance)
 		return newBalance, nil
 	}
 	// TRC tokens
@@ -200,7 +200,7 @@ func CheckSubTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			return nil, errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		newBalance := new(big.Int).Sub(balance, value)
-		log.Debug("CheckSubTokenBalance settle balance: SUB TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckSubTokenBalance settle balance: SUB TOKEN BALANCE ", "token", token, "address", addr, "balance", balance, "value", value, "newBalance", newBalance)
 		return newBalance, nil
 	} else {
 		return nil, errors.Errorf("token %s isn't exist", token.String())
@@ -217,7 +217,7 @@ func CheckAddTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			balance = statedb.GetBalance(addr)
 		}
 		newBalance := new(big.Int).Add(balance, value)
-		log.Debug("CheckAddTokenBalance settle balance: ADD XDC NATIVE BALANCE ", "token", common.XDCNativeAddress, "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckAddTokenBalance settle balance: ADD XDC NATIVE BALANCE ", "token", common.XDCNativeAddress, "address", addr, "balance", balance, "value", value, "newBalance", newBalance)
 		return newBalance, nil
 	}
 	// TRC tokens
@@ -231,7 +231,7 @@ func CheckAddTokenBalance(addr common.Address, value *big.Int, token common.Addr
 			balance = statedb.GetState(token, locHash).Big()
 		}
 		newBalance := new(big.Int).Add(balance, value)
-		log.Debug("CheckAddTokenBalance settle balance: ADD TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		log.Debug("CheckAddTokenBalance settle balance: ADD TOKEN BALANCE ", "token", token, "address", addr, "balance", balance, "value", value, "newBalance", newBalance)
 		if common.BigToHash(newBalance).Big().Cmp(newBalance) != 0 {
 			return nil, fmt.Errorf("overflow when try add token balance , max is 2^256 , balance : %v , value : %v", balance, value)
 		} else {
@@ -251,7 +251,7 @@ func CheckSubRelayerFee(relayer common.Address, fee *big.Int, statedb *state.Sta
 		locHashDeposit := common.BigToHash(locBigDeposit)
 		balance = statedb.GetState(common.RelayerRegistrationSMC, locHashDeposit).Big()
 	}
-	log.Debug("CheckSubRelayerFee settle balance: SubRelayerFee ", "relayer", relayer.String(), "balance", balance, "fee", fee)
+	log.Debug("CheckSubRelayerFee settle balance: SubRelayerFee ", "relayer", relayer, "balance", balance, "fee", fee)
 	if balance.Cmp(fee) < 0 {
 		return nil, errors.Errorf("relayer %s isn't enough XDC fee", relayer.String())
 	} else {

--- a/XDCxlending/order_processor.go
+++ b/XDCxlending/order_processor.go
@@ -700,7 +700,7 @@ func (l *Lending) ProcessCancelOrder(header *types.Header, lendingStateDB *lendi
 	}
 	lendTokenDecimal, err := l.XDCx.GetTokenDecimal(chain, statedb, originOrder.LendingToken)
 	if err != nil || lendTokenDecimal == nil || lendTokenDecimal.Sign() <= 0 {
-		log.Debug("Fail to get tokenDecimal ", "Token", originOrder.LendingToken.String(), "err", err)
+		log.Debug("Fail to get tokenDecimal ", "Token", originOrder.LendingToken, "err", err)
 		return err, false
 	}
 	var tokenBalance *big.Int
@@ -723,7 +723,7 @@ func (l *Lending) ProcessCancelOrder(header *types.Header, lendingStateDB *lendi
 		}
 		collateralTokenDecimal, err = l.XDCx.GetTokenDecimal(chain, statedb, originOrder.CollateralToken)
 		if err != nil || collateralTokenDecimal == nil || collateralTokenDecimal.Sign() <= 0 {
-			log.Debug("Fail to get tokenDecimal ", "Token", originOrder.LendingToken.String(), "err", err)
+			log.Debug("Fail to get tokenDecimal ", "Token", originOrder.LendingToken, "err", err)
 			return err, false
 		}
 	}

--- a/common/types.go
+++ b/common/types.go
@@ -245,6 +245,10 @@ func IsHexAddress(s string) bool {
 	return len(s) == 2*AddressLength && isHex(s)
 }
 
+func (a Address) TerminalString() string {
+	return string(a.checksumHex())
+}
+
 // IsZero returns if a address is empty
 func (a Address) IsZero() bool { return a == Address{} }
 

--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -457,7 +457,7 @@ func (x *XDPoS_v1) yourTurn(chain consensus.ChainReader, parent *types.Header, s
 		log.Debug("Masternodes cycle info", "number of masternodes", len(masternodes), "previous", pre, "position", preIndex, "current", signer, "position", curIndex)
 	}
 	for i, s := range masternodes {
-		log.Debug("Masternode:", "index", i, "address", s.String())
+		log.Debug("Masternode:", "index", i, "address", s)
 	}
 	if (preIndex+1)%len(masternodes) == curIndex {
 		return len(masternodes), preIndex, curIndex, true, nil
@@ -616,7 +616,7 @@ func (x *XDPoS_v1) verifySeal(chain consensus.ChainReader, header *types.Header,
 			}
 		}
 		if !valid {
-			log.Debug("Unauthorized creator found", "block number", number, "creator", creator.String(), "masternodes", mstring, "snapshot from parent block", nstring)
+			log.Debug("Unauthorized creator found", "block number", number, "creator", creator, "masternodes", mstring, "snapshot from parent block", nstring)
 			return utils.ErrUnauthorized
 		}
 	}

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -598,7 +598,7 @@ func (x *XDPoS_v2) UpdateMasternodes(chain consensus.ChainReader, header *types.
 
 	log.Info("[UpdateMasternodes] New set of masternodes has been updated to snapshot", "number", snap.Number, "hash", snap.Hash)
 	for i, n := range ms {
-		log.Info("masternode", "index", i, "address", n.Address.String())
+		log.Info("masternode", "index", i, "address", n.Address)
 	}
 
 	return nil

--- a/consensus/XDPoS/engines/engine_v2/mining.go
+++ b/consensus/XDPoS/engines/engine_v2/mining.go
@@ -41,7 +41,7 @@ func (x *XDPoS_v2) yourturn(chain consensus.ChainReader, round types.Round, pare
 	}
 
 	for i, s := range masterNodes {
-		log.Debug("[yourturn] Masternode:", "index", i, "address", s.String(), "parentBlockNum", parent.Number)
+		log.Debug("[yourturn] Masternode:", "index", i, "address", s, "parentBlockNum", parent.Number)
 	}
 
 	curIndex := utils.Position(masterNodes, signer)

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -476,7 +476,7 @@ func GetRewardBalancesRate(foundationWalletAddr common.Address, statedb *state.S
 		log.Error("Fail to parse json holders", "error", err)
 		return nil, err
 	}
-	log.Trace("Holders reward", "holders", string(jsonHolders), "masternode", masterAddr.String())
+	log.Trace("Holders reward", "holders", string(jsonHolders), "masternode", masterAddr)
 
 	return balances, nil
 }

--- a/contracts/validator/validator_test.go
+++ b/contracts/validator/validator_test.go
@@ -235,7 +235,7 @@ func GetRewardBalancesRate(foudationWalletAddr common.Address, masterAddr common
 		log.Error("Fail to parse json holders", "error", err)
 		return nil, err
 	}
-	log.Info("Holders reward", "holders", string(jsonHolders), "masternode", masterAddr.String())
+	log.Info("Holders reward", "holders", string(jsonHolders), "masternode", masterAddr)
 
 	return balances, nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2808,7 +2808,7 @@ func (bc *BlockChain) UpdateM1() error {
 		})
 		log.Info("Ordered list of masternode candidates")
 		for _, m := range ms {
-			log.Info("", "address", m.Address.String(), "stake", m.Stake)
+			log.Info("", "address", m.Address, "stake", m.Stake)
 		}
 		// update masternodes
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -897,7 +897,7 @@ func (api *BlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAddres
 			result[fieldStatus] = statusMasternode
 			if !isCandidate {
 				result[fieldCapacity] = -1
-				log.Warn("Find non-candidate masternode", "masternode", masternode.String(), "checkpointNumber", checkpointNumber, "epoch", epoch, "epochNumber", epochNumber)
+				log.Warn("Find non-candidate masternode", "masternode", masternode, "checkpointNumber", checkpointNumber, "epoch", epoch, "epochNumber", epochNumber)
 			}
 			return result, nil
 		}


### PR DESCRIPTION
# Proposed changes

This PR implements `TerminalStringer` interface for `Address` type to close #1832.

In the file `log/format.go` 

```go
// FormatSlogValue formats a slog.Value for serialization to terminal.
func FormatSlogValue(v slog.Value, tmp []byte) (result []byte) {
    // ......
	case TerminalStringer:
		return appendEscapeString(tmp, v.TerminalString())
	case fmt.Stringer:
		return appendEscapeString(tmp, v.String())
```

`TerminalStringer` has higher priority than `fmt. Stringer`. The `Address` type only implements `fmt. Stringer` but does not implements the `TerminalStringer`.So I implement `TerminalStringer` which use 0x prefix for `Adress` type.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
