### PR TITLE
core/txpool: check if initcode size is exceeded #26504

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -626,6 +626,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if tx.Size() > txMaxSize {
 		return ErrOversizedData
 	}
+	// Check whether the init code size has been exceeded.
+	if pool.eip1559 && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
+		return fmt.Errorf("%w: code size %v limit %v", core.ErrMaxInitCodeSizeExceeded, len(tx.Data()), params.MaxInitCodeSize)
+	}
 	// Get current block number
 	var number *big.Int = nil
 	if pool.chain.CurrentHeader() != nil {


### PR DESCRIPTION
# Proposed changes

This PR makes sure that only transactions that do not exceed the initcode size make it into the txpool. The transactions with `initdata > MaxInitCodeSize` were not rejected by the transaction pool now. They would be rejected by nodes executing them, but not by the txpool. This could've been used to flood a txpool with unexecutable transactions. Since they are valid looking, they would be propagated to peers and stay in the mempool.

Ref: #26504

in the file `core/state_transition.go`:

```go
// Check whether the init code size has been exceeded.
	if rules.IsEIP1559 && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
	}
```

So we can reject big tx early.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
