### PR TITLE
all: use FinalizedBlockNumber instead of CommittedBlockNumber

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -955,7 +955,7 @@ func (fb *filterBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNum
 		return nil, nil
 	case rpc.LatestBlockNumber:
 		return fb.bc.CurrentHeader(), nil
-	case rpc.CommittedBlockNumber:
+	case rpc.FinalizedBlockNumber:
 		if fb.bc.Config().XDPoS == nil {
 			return nil, errors.New("only XDPoS v2 supports committed block lookup")
 		}

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -192,7 +192,7 @@ func (api *API) GetMasternodesByNumber(number *rpc.BlockNumber) MasternodesStatu
 	var header *types.Header
 	if number == nil || *number == rpc.LatestBlockNumber {
 		header = api.chain.CurrentHeader()
-	} else if *number == rpc.CommittedBlockNumber {
+	} else if *number == rpc.FinalizedBlockNumber {
 		if info := api.XDPoS.EngineV2.GetLatestCommittedBlockInfo(); info != nil {
 			header = api.chain.GetHeaderByHash(info.Hash)
 		}
@@ -403,7 +403,7 @@ func (api *API) getHeaderFromApiBlockNum(number *rpc.BlockNumber) (*types.Header
 	var header *types.Header
 	if number == nil || *number == rpc.LatestBlockNumber {
 		header = api.chain.CurrentHeader()
-	} else if *number == rpc.CommittedBlockNumber {
+	} else if *number == rpc.FinalizedBlockNumber {
 		if info := api.XDPoS.EngineV2.GetLatestCommittedBlockInfo(); info != nil {
 			header = api.chain.GetHeaderByHash(info.Hash)
 		}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -86,7 +86,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock().Header(), nil
 	}
-	if number == rpc.CommittedBlockNumber {
+	if number == rpc.FinalizedBlockNumber {
 		if b.eth.chainConfig.XDPoS == nil {
 			return nil, errors.New("PoW does not support confirmed block lookup")
 		}
@@ -138,7 +138,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
-	if number == rpc.CommittedBlockNumber {
+	if number == rpc.FinalizedBlockNumber {
 		if b.eth.chainConfig.XDPoS == nil {
 			return nil, errors.New("PoW does not support confirmed block lookup")
 		}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -131,8 +131,8 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 			if hdr == nil {
 				return 0, errors.New("latest header not found")
 			}
-		case rpc.CommittedBlockNumber.Int64():
-			hdr, _ = f.sys.backend.HeaderByNumber(ctx, rpc.CommittedBlockNumber)
+		case rpc.FinalizedBlockNumber.Int64():
+			hdr, _ = f.sys.backend.HeaderByNumber(ctx, rpc.FinalizedBlockNumber)
 			if hdr == nil {
 				return 0, errors.New("committed header not found")
 			}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -79,7 +79,7 @@ func (b *testBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumbe
 			return nil, nil
 		}
 		num = *number
-	case rpc.CommittedBlockNumber:
+	case rpc.FinalizedBlockNumber:
 		return nil, nil
 	default:
 		num = uint64(blockNr)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -300,13 +300,13 @@ func TestFilters(t *testing.T) {
 			f:    sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
 			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x21fd39694cbcc8cc5046b3b7d5200101edf9c85218da613a8851eb5e3d195241","transactionIndex":"0x0","blockHash":"0x8a956d79ca6468ff23c97615a4aa24a55bdaff78767ee28d3e2e02ecb407a0de","logIndex":"0x0","removed":false}]`,
 		}, {
-			f:   sys.NewRangeFilter(int64(rpc.CommittedBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
+			f:   sys.NewRangeFilter(int64(rpc.FinalizedBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
 			err: "committed header not found",
 		}, {
-			f:   sys.NewRangeFilter(int64(rpc.CommittedBlockNumber), int64(rpc.CommittedBlockNumber), nil, nil),
+			f:   sys.NewRangeFilter(int64(rpc.FinalizedBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil),
 			err: "committed header not found",
 		}, {
-			f:   sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.CommittedBlockNumber), nil, nil),
+			f:   sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil),
 			err: "committed header not found",
 		}, {
 			f:    sys.NewRangeFilter(int64(rpc.PendingBlockNumber), int64(rpc.PendingBlockNumber), nil, nil),

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -178,8 +178,8 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, reqEnd rpc.BlockNum
 		case rpc.LatestBlockNumber:
 			// Retrieved above.
 			resolved = headBlock
-		case rpc.CommittedBlockNumber:
-			resolved, err = oracle.backend.HeaderByNumber(ctx, rpc.CommittedBlockNumber)
+		case rpc.FinalizedBlockNumber:
+			resolved, err = oracle.backend.HeaderByNumber(ctx, rpc.FinalizedBlockNumber)
 		case rpc.EarliestBlockNumber:
 			resolved, err = oracle.backend.HeaderByNumber(ctx, rpc.EarliestBlockNumber)
 		}

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -50,7 +50,7 @@ func TestFeeHistory(t *testing.T) {
 		{false, 1000, 1000, 2, rpc.PendingBlockNumber, nil, 32, 1, nil},
 		{true, 1000, 1000, 2, rpc.PendingBlockNumber, nil, 32, 2, nil},
 		{true, 1000, 1000, 2, rpc.PendingBlockNumber, []float64{0, 10}, 32, 2, nil},
-		{false, 1000, 1000, 2, rpc.CommittedBlockNumber, []float64{0, 10}, 32, 1, nil},
+		{false, 1000, 1000, 2, rpc.FinalizedBlockNumber, []float64{0, 10}, 32, 1, nil},
 	}
 	for i, c := range cases {
 		config := Config{

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -48,7 +48,7 @@ func (b *testBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber
 	if number == rpc.EarliestBlockNumber {
 		number = 0
 	}
-	if number == rpc.CommittedBlockNumber {
+	if number == rpc.FinalizedBlockNumber {
 		return b.chain.CurrentBlock().Header(), nil
 	}
 	if number == rpc.LatestBlockNumber {
@@ -71,7 +71,7 @@ func (b *testBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber)
 	if number == rpc.EarliestBlockNumber {
 		number = 0
 	}
-	if number == rpc.CommittedBlockNumber {
+	if number == rpc.FinalizedBlockNumber {
 		return b.chain.CurrentBlock(), nil
 	}
 	if number == rpc.LatestBlockNumber {

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -47,8 +47,8 @@ func TestBlockNumberJSONUnmarshal(t *testing.T) {
 		11: {`"pending"`, false, PendingBlockNumber},
 		12: {`"latest"`, false, LatestBlockNumber},
 		13: {`"earliest"`, false, EarliestBlockNumber},
-		14: {`"committed"`, false, CommittedBlockNumber},
-		15: {`"finalized"`, false, CommittedBlockNumber},
+		14: {`"committed"`, false, FinalizedBlockNumber},
+		15: {`"finalized"`, false, FinalizedBlockNumber},
 		16: {`someString`, true, BlockNumber(0)},
 		17: {`""`, true, BlockNumber(0)},
 		18: {``, true, BlockNumber(0)},
@@ -98,8 +98,8 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		11: {`"pending"`, false, BlockNumberOrHashWithNumber(PendingBlockNumber)},
 		12: {`"latest"`, false, BlockNumberOrHashWithNumber(LatestBlockNumber)},
 		13: {`"earliest"`, false, BlockNumberOrHashWithNumber(EarliestBlockNumber)},
-		14: {`"committed"`, false, BlockNumberOrHashWithNumber(CommittedBlockNumber)},
-		15: {`"finalized"`, false, BlockNumberOrHashWithNumber(CommittedBlockNumber)},
+		14: {`"committed"`, false, BlockNumberOrHashWithNumber(FinalizedBlockNumber)},
+		15: {`"finalized"`, false, BlockNumberOrHashWithNumber(FinalizedBlockNumber)},
 		16: {`someString`, true, BlockNumberOrHash{}},
 		17: {`""`, true, BlockNumberOrHash{}},
 		18: {``, true, BlockNumberOrHash{}},
@@ -111,8 +111,8 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		24: {`{"blockNumber":"pending"}`, false, BlockNumberOrHashWithNumber(PendingBlockNumber)},
 		25: {`{"blockNumber":"latest"}`, false, BlockNumberOrHashWithNumber(LatestBlockNumber)},
 		26: {`{"blockNumber":"earliest"}`, false, BlockNumberOrHashWithNumber(EarliestBlockNumber)},
-		27: {`{"blockNumber":"committed"}`, false, BlockNumberOrHashWithNumber(CommittedBlockNumber)},
-		28: {`{"blockNumber":"finalized"}`, false, BlockNumberOrHashWithNumber(CommittedBlockNumber)},
+		27: {`{"blockNumber":"committed"}`, false, BlockNumberOrHashWithNumber(FinalizedBlockNumber)},
+		28: {`{"blockNumber":"finalized"}`, false, BlockNumberOrHashWithNumber(FinalizedBlockNumber)},
 		29: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
 	}
 
@@ -150,8 +150,8 @@ func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 		{"pending", int64(PendingBlockNumber)},
 		{"latest", int64(LatestBlockNumber)},
 		{"earliest", int64(EarliestBlockNumber)},
-		{"committed", int64(CommittedBlockNumber)},
-		{"finalized", int64(CommittedBlockNumber)},
+		{"committed", int64(FinalizedBlockNumber)},
+		{"finalized", int64(FinalizedBlockNumber)},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestBlockNumberOrHash_StringAndUnmarshal(t *testing.T) {
 		BlockNumberOrHashWithNumber(PendingBlockNumber),
 		BlockNumberOrHashWithNumber(LatestBlockNumber),
 		BlockNumberOrHashWithNumber(EarliestBlockNumber),
-		BlockNumberOrHashWithNumber(CommittedBlockNumber),
+		BlockNumberOrHashWithNumber(FinalizedBlockNumber),
 		BlockNumberOrHashWithNumber(32),
 		BlockNumberOrHashWithHash(common.Hash{0xaa}, false),
 	}


### PR DESCRIPTION
# Proposed changes

rename `CommittedBlockNumber` to `FinalizedBlockNumber`, keep code consistent with geth. 

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
