### PR TITLE
rpc: use `finalized` when marshal BlockNumber

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -95,7 +95,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "pending":
 		*bn = PendingBlockNumber
 		return nil
-	case "committed", "finalized":
+	case "finalized", "committed":
 		*bn = FinalizedBlockNumber
 		return nil
 	}
@@ -144,7 +144,7 @@ func (bn BlockNumber) String() string {
 	case PendingBlockNumber:
 		return "pending"
 	case FinalizedBlockNumber:
-		return "committed"
+		return "finalized"
 	default:
 		if bn < 0 {
 			return fmt.Sprintf("<invalid %d>", bn)
@@ -213,7 +213,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		bn := PendingBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
-	case "committed", "finalized":
+	case "finalized", "committed":
 		bn := FinalizedBlockNumber
 		bnh.BlockNumber = &bn
 		return nil


### PR DESCRIPTION
# Proposed changes

This PR use `finalized` instead of `committed` when marshal type `BlockNumber` since geth use `finalized`.

**Notice: This is a break change**

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
