### PR TITLE
XFN-155: consensus V2 initial timer kick-off check

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -200,7 +200,7 @@ func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) er
 	var quorumCert *types.QuorumCert
 	var err error
 
-	if header.Number.Int64() == x.config.V2.SwitchBlock.Int64() {
+	if header.Number.Cmp(x.config.V2.SwitchBlock) == 0 {
 		log.Info("[initial] highest QC for consensus v2 first block")
 		blockInfo := &types.BlockInfo{
 			Hash:   header.Hash(),
@@ -275,7 +275,7 @@ func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) er
 	// Kick-off the countdown timer
 	// Only kick-off if it is V2 switch block
 	// Otherwise it is a lagging node, already kick-off in `processQC`
-	if header.Number.Int64() == x.config.V2.SwitchBlock.Int64() {
+	if header.Number.Cmp(x.config.V2.SwitchBlock) == 0 {
 		x.timeoutWorker.Reset(chain, 0, 0)
 	}
 	x.isInitilised = true
@@ -993,7 +993,7 @@ func (x *XDPoS_v2) calcMasternodes(chain consensus.ChainReader, blockNum *big.In
 	}
 	candidates := snap.NextEpochCandidates
 
-	if blockNum.Uint64() == x.config.V2.SwitchBlock.Uint64()+1 {
+	if blockNum.Cmp(new(big.Int).Add(x.config.V2.SwitchBlock, big.NewInt(1))) == 0 {
 		log.Info("[calcMasternodes] examing first v2 block")
 		if len(candidates) > maxMasternodes {
 			candidates = candidates[:maxMasternodes]


### PR DESCRIPTION
# Proposed changes
consensus V2 initial timer kick-off check. if the node already passed V2 switch block, if doesn't need to kick-off the timer with 0.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
