### PR TITLE
rlp: finalize listIterator on parse error to prevent non-advancing loops#33245

### DIFF
--- a/rlp/iterator.go
+++ b/rlp/iterator.go
@@ -37,15 +37,24 @@ func NewListIterator(data RawValue) (*listIterator, error) {
 	return it, nil
 }
 
-// Next forwards the iterator one step, returns true if it was not at end yet
+// Next forwards the iterator one step.
+// Returns true if there is a next item or an error occurred on this step (check Err()).
+// On parse error, the iterator is marked finished and subsequent calls return false.
 func (it *listIterator) Next() bool {
 	if len(it.data) == 0 {
 		return false
 	}
 	_, t, c, err := readKind(it.data)
+	if err != nil {
+		it.next = nil
+		it.err = err
+		// Mark iteration as finished to avoid potential infinite loops on subsequent Next calls.
+		it.data = nil
+		return true
+	}
 	it.next = it.data[:t+c]
 	it.data = it.data[t+c:]
-	it.err = err
+	it.err = nil
 	return true
 }
 


### PR DESCRIPTION
# Proposed changes

rlp: finalize listIterator on parse error to prevent non-advancing loops#33245

Ref: #33245

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
