### PR TITLE
rpc: fix a flaky test of the websocket #33002

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -971,7 +971,7 @@ func (l *flakeyListener) Accept() (net.Conn, error) {
 
 	c, err := l.Listener.Accept()
 	if err == nil {
-		timeout := time.Duration(rand.Int63n(int64(l.maxKillTimeout)))
+		timeout := max(time.Millisecond*10, time.Duration(rand.Int63n(int64(l.maxKillTimeout))))
 		time.AfterFunc(timeout, func() {
 			log.Debug(fmt.Sprintf("killing conn %v after %v", c.LocalAddr(), timeout))
 			c.Close()


### PR DESCRIPTION
# Proposed changes

Fix a flaky test of the websocket

Ref: #33002

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
