### PR TITLE
cmd/XDC: fix txpool gasPrice being overridden at checkpoints

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -361,8 +361,6 @@ func startNode(ctx *cli.Context, stack *node.Node, backend ethapi.Backend, cfg X
 						th.SetThreads(threads)
 					}
 				}
-				// Set the gas price to the limits from the CLI and start mining
-				ethBackend.TxPool().SetGasPrice(cfg.Eth.GasPrice)
 				if err := ethBackend.StartStaking(true); err != nil {
 					utils.Fatalf("Failed to start staking: %v", err)
 				}
@@ -398,8 +396,6 @@ func startNode(ctx *cli.Context, stack *node.Node, backend ethapi.Backend, cfg X
 							th.SetThreads(threads)
 						}
 					}
-					// Set the gas price to the limits from the CLI and start mining
-					ethBackend.TxPool().SetGasPrice(cfg.Eth.GasPrice)
 					if err := ethBackend.StartStaking(true); err != nil {
 						utils.Fatalf("Failed to start staking: %v", err)
 					}


### PR DESCRIPTION
# Proposed changes

This PR removes two redundant SetGasPrice() calls in the startNode function that were causing multiple issues:

1. Overriding txpool's configured price limit with the miner's gas price setting, mixing two independent configurations:

- cfg.Eth.GasPrice (from --miner-gasprice --gasprice flag)  
- cfg.TxPool.PriceLimit (from --txpool-pricelimit flag)

2. Reverting runtime gasPrice changes made via RPC. When users call miner_setGasPrice RPC method to adjust the gasPrice dynamically, the changes would be unexpectedly reverted at the next checkpoint when startNode re-applies cfg.Eth.GasPrice.

The txpool already initializes its gasPrice from config.PriceLimit during construction (core/txpool/txpool.go:333):

```go
func NewTxPool(config Config, chainconfig *params.ChainConfig, chain blockChain) *TxPool {
	pool := &TxPool{
		gasPrice:         new(big.Int).SetUint64(config.PriceLimit),
	}
```

When mining is started via RPC (miner_start), the MinerAPI.Start() method handles gasPrice propagation correctly.

This change ensures:

- The txpool respects its own configuration
- Runtime gasPrice adjustments via RPC persist across checkpoints
- No unexpected overriding of user-configured values

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
