### PR TITLE
contracts, tests: fix global variable modifications and remove unsafe parallelism

### DIFF
--- a/contracts/tests/Inherited_test.go
+++ b/contracts/tests/Inherited_test.go
@@ -25,7 +25,12 @@ func TestPriceFeed(t *testing.T) {
 	glogger.Verbosity(log.LevelTrace)
 	log.SetDefault(log.NewLogger(glogger))
 
+	oldTIPXDCXCancellationFee := new(big.Int).Set(common.TIPXDCXCancellationFee)
+	defer func() {
+		common.TIPXDCXCancellationFee = oldTIPXDCXCancellationFee
+	}()
 	common.TIPXDCXCancellationFee = big.NewInt(0)
+
 	// init genesis
 	contractBackend := backends.NewXDCSimulatedBackend(
 		types.GenesisAlloc{

--- a/contracts/trc21issuer/trc21issuer_test.go
+++ b/contracts/trc21issuer/trc21issuer_test.go
@@ -23,16 +23,13 @@ var (
 	subKey, _ = crypto.HexToECDSA("5bb98c5f937d176aa399ea6e6541f4db8f8db5a4ee1a8b56fb8beb41f2d755e3")
 	subAddr   = crypto.PubkeyToAddress(subKey.PublicKey) //0x21292d56E2a8De3cC4672dB039AAA27f9190B1f6
 
-	token = common.HexToAddress("0000000000000000000000000000000000000089")
-
-	delay    = big.NewInt(30 * 48)
 	minApply = big.NewInt(0).Mul(big.NewInt(1000), big.NewInt(100000000000000000)) // 100 XDC
 )
 
 func TestFeeTxWithTRC21Token(t *testing.T) {
-	oldTRC21GasPriceBefore := new(big.Int).Set(common.TIPTRC21Fee)
+	oldTRC21GasPriceBefore := new(big.Int).Set(common.TRC21GasPriceBefore)
 	defer func() {
-		common.TIPTRC21Fee = oldTRC21GasPriceBefore
+		common.TRC21GasPriceBefore = oldTRC21GasPriceBefore
 	}()
 	common.TRC21GasPriceBefore = big.NewInt(1)
 
@@ -54,7 +51,12 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 	contractBackend.Commit()
 
 	// set contract address to config
+	oldTRC21IssuerSMC := common.TRC21IssuerSMC
+	defer func() {
+		common.TRC21IssuerSMC = oldTRC21IssuerSMC
+	}()
 	common.TRC21IssuerSMC = trc21IssuerAddr
+
 	cap := big.NewInt(0).Mul(big.NewInt(10000000), big.NewInt(10000000000000))
 	TRC21fee := big.NewInt(100)
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -25,8 +25,11 @@ import (
 )
 
 func TestVM(t *testing.T) {
+	oldTIPXDCXCancellationFee := new(big.Int).Set(common.TIPXDCXCancellationFee)
+	defer func() {
+		common.TIPXDCXCancellationFee = oldTIPXDCXCancellationFee
+	}()
 	common.TIPXDCXCancellationFee = big.NewInt(100000000)
-	t.Parallel()
 	vmt := new(testMatcher)
 	vmt.fails("^vmSystemOperationsTest.json/createNameRegistrator$", "fails without parallel execution")
 


### PR DESCRIPTION
# Proposed changes

Add defer cleanup for global variables and remove t.Parallel() where global state is modified to prevent race conditions and test pollution.

Changes:

1. tests/vm_test.go:

- Add defer to restore common.TIPXDCXCancellationFee
- Remove t.Parallel() since modifying global variable makes concurrent execution unsafe, even with defer cleanup
- Prevents potential race conditions with other tests in the package

2. contracts/tests/Inherited_test.go:

- Add defer to restore common.TIPXDCXCancellationFee
- No t.Parallel() present, so safe with defer alone

3. contracts/trc21issuer/trc21issuer_test.go:

- Add defer to restore common.TRC21IssuerSMC (was missing)
- Fix existing bug: restore correct variable common.TRC21GasPriceBefore instead of common.TIPTRC21Fee
- Remove unused variables: token, delay

Rationale for removing t.Parallel():
While defer ensures cleanup after test completion, during test execution the modified global variable is visible to all concurrent tests. Even though tests/vm_test.go is currently the only test modifying TIPXDCXCancellationFee, removing t.Parallel() is the safer approach to ensure complete test isolation and prevent timing-dependent behavior.

This follows the same principles as the txpool MinGasPrice fix: global variable modifications should not occur during concurrent test execution.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
