### PR TITLE
core, consensus: use `slice.Clip` capacity to simplify code

### DIFF
--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -580,7 +580,7 @@ func (api *API) getRewardFileNamesInRange(begin, end *rpc.BlockNumber) ([]reward
 
 	// compact the slice's memory
 	ret := rewardFileNames[startIndex:endIndex]
-	return ret[:len(ret):len(ret)], nil
+	return slices.Clip(ret), nil
 }
 
 func getEpochReward(account common.Address, header *types.Header) (AccountEpochReward, error) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"errors"
 	"math/big"
+	"slices"
 	"sync/atomic"
 
 	"github.com/XinFinOrg/XDPoSChain/XDCx/tradingstate"
@@ -170,20 +171,20 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, tradingStat
 	default:
 		evm.table = &frontierInstructionSet
 	}
+	var extraEips []int
 	if len(evm.Config.ExtraEips) > 0 {
 		// Deep-copy jumptable to prevent modification of opcodes in other tables
 		evm.table = copyJumpTable(evm.table)
-	}
-	extraEips := make([]int, 0, len(evm.Config.ExtraEips))
-	for _, eip := range evm.Config.ExtraEips {
-		if err := EnableEIP(eip, evm.table); err != nil {
-			// Disable it, so caller can check if it's activated or not
-			log.Error("EIP activation failed", "eip", eip, "error", err)
-		} else {
-			extraEips = append(extraEips, eip)
+		for _, eip := range evm.Config.ExtraEips {
+			if err := EnableEIP(eip, evm.table); err != nil {
+				// Disable it, so caller can check if it's activated or not
+				log.Error("EIP activation failed", "eip", eip, "error", err)
+			} else {
+				extraEips = append(extraEips, eip)
+			}
 		}
 	}
-	evm.Config.ExtraEips = extraEips[0:len(extraEips):len(extraEips)]
+	evm.Config.ExtraEips = slices.Clip(extraEips)
 
 	return evm
 }


### PR DESCRIPTION
# Proposed changes

Use `slice.Clip` capacity to avoid sharing

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
