### PR TITLE
core/types: separate special transactions correctly

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -785,19 +785,20 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 	for _, accTxs := range txs {
 		from, _ := Sender(signer, accTxs[0])
 		var normalTxs Transactions
-		lastSpecialTx := -1
-		if lastSpecialTx >= 0 {
-			for i := 0; i <= lastSpecialTx; i++ {
-				specialTxs = append(specialTxs, accTxs[i])
+		for _, tx := range accTxs {
+			if tx.IsSpecialTransaction() {
+				specialTxs = append(specialTxs, tx)
+			} else {
+				normalTxs = append(normalTxs, tx)
 			}
-			normalTxs = accTxs[lastSpecialTx+1:]
-		} else {
-			normalTxs = accTxs
 		}
 		if len(normalTxs) > 0 {
 			heads.txs = append(heads.txs, normalTxs[0])
-			// Ensure the sender address is from the signer
+			// Remove the first normal transaction for this sender
 			txs[from] = normalTxs[1:]
+		} else {
+			// Remove the account if there are no normal transactions
+			delete(txs, from)
 		}
 	}
 	heap.Init(&heads)


### PR DESCRIPTION
# Proposed changes

- Refactor NewTransactionsByPriceAndNonce to properly filter and separate special transactions (IsSpecialTransaction)
- Remove account from txs map if it has no normal transactions left
- Update comments for clarity

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
