### PR TITLE
miner: fix block number extraction for BlockSigner tx

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -18,7 +18,6 @@ package miner
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -1020,7 +1019,7 @@ func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Addr
 				log.Trace("Data special transaction invalid length", "hash", hash, "data", len(data))
 				continue
 			}
-			blkNumber := binary.BigEndian.Uint64(data[8:40])
+			blkNumber := new(big.Int).SetBytes(data[4:36]).Uint64()
 			if blkNumber >= w.header.Number.Uint64() || blkNumber+w.config.XDPoS.Epoch*2 <= w.header.Number.Uint64() {
 				log.Trace("Data special transaction invalid number", "hash", hash, "blkNumber", blkNumber, "miner", w.header.Number)
 				continue


### PR DESCRIPTION
# Proposed changes

Previously, the code used binary.BigEndian.Uint64(data[8:40]), which incorrectly read the index and only extracted the highest 8 bytes of the 32-byte left-padded block number, resulting in wrong values (often zero). Now, the code uses new(big.Int).SetBytes(data[4:36]).Uint64() to correctly extract the block number from the proper 32-byte field. This change fixes both the incorrect index and the parsing logic, ensuring accurate block number extraction and correct validation for special transactions.

eg:

when data is `e341eaa4000000000000000000000000000000000000000000000000000000000000000f077c098bfe0729811df156252455c1debd1a8e4b7e781d8c7384ea32d15e5021`

old(wrong):
`data[8:40]` is `0000000000000000000000000000000000000000000000000000000f077c098b`
blkNumber is 0

new(right):
`data[4:36]` is `000000000000000000000000000000000000000000000000000000000000000f`
blkNumber is 15

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
