### PR TITLE
core/txpool: use right type for field Txs in NewTxsEvent

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -971,7 +971,7 @@ func (pool *TxPool) promoteSpecialTx(addr common.Address, tx *types.Transaction,
 	// Set the potentially new pending nonce and notify any subsystems of the new tx
 	pool.beats[addr] = time.Now()
 	pool.pendingNonces.set(addr, tx.Nonce()+1)
-	go pool.txFeed.Send(core.NewTxsEvent{Txs: types.Transactions{tx}})
+	pool.txFeed.Send(core.NewTxsEvent{Txs: []*types.Transaction{tx}})
 	return true, nil
 }
 


### PR DESCRIPTION
# Proposed changes

This PR:

- updates the Txs field in NewTxsEvent to use []*types.Transaction instead of types.Transactions. This ensures type consistency for event broadcasting and handling, improving reliability of transaction propagation across the network. 
- removes unnecessary goroutine usage for txFeed.Send, making event delivery synchronous and safer for downstream consumers.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
