### PR TITLE
increase timeout to 5 mins to let node mine out block

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -88,6 +88,14 @@ var (
 			TimeoutPeriod:        10,
 			MinePeriod:           2,
 		},
+		17584000: {
+			MaxMasternodes:       108,
+			SwitchRound:          17584000,
+			CertThreshold:        0.667,
+			TimeoutSyncThreshold: 3,
+			TimeoutPeriod:        300,
+			MinePeriod:           2,
+		},
 	}
 
 	TestnetV2Configs = map[uint64]*V2Config{

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 2        // Major version component of the current release
 	VersionMinor = 4        // Minor version component of the current release
 	VersionPatch = 2        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMeta  = "hotfix" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
# Proposed changes
increase timeout to 5 mins to let node mine out block
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
