### PR TITLE
params: fix V2 compare issue

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -19,7 +19,6 @@ package params
 import (
 	"fmt"
 	"math/big"
-	"slices"
 	"strings"
 	"sync"
 
@@ -489,63 +488,65 @@ type ExpTimeoutConfig struct {
 
 func XDPoSConfigEqual(a, b *XDPoSConfig) bool {
 	if a == nil || b == nil {
-		log.Info("[XDPoSConfigEqual] Nil check", "a", a, "b", b, "equal", a == b)
-		return a == b
+		if a != b {
+			log.Warn("[XDPoSConfigEqual] One of the configs is nil", "a", a, "b", b)
+			return false
+		}
+		return true
 	}
-
 	if a.Period != b.Period {
-		log.Info("[XDPoSConfigEqual] Period mismatch", "a.Period", a.Period, "b.Period", b.Period)
+		log.Warn("[XDPoSConfigEqual] Period mismatch", "a.Period", a.Period, "b.Period", b.Period)
 		return false
 	}
 	if a.Epoch != b.Epoch {
-		log.Info("[XDPoSConfigEqual] Epoch mismatch", "a.Epoch", a.Epoch, "b.Epoch", b.Epoch)
+		log.Warn("[XDPoSConfigEqual] Epoch mismatch", "a.Epoch", a.Epoch, "b.Epoch", b.Epoch)
 		return false
 	}
 	if a.Reward != b.Reward {
-		log.Info("[XDPoSConfigEqual] Reward mismatch", "a.Reward", a.Reward, "b.Reward", b.Reward)
+		log.Warn("[XDPoSConfigEqual] Reward mismatch", "a.Reward", a.Reward, "b.Reward", b.Reward)
 		return false
 	}
 	if a.RewardCheckpoint != b.RewardCheckpoint {
-		log.Info("[XDPoSConfigEqual] RewardCheckpoint mismatch", "a.RewardCheckpoint", a.RewardCheckpoint, "b.RewardCheckpoint", b.RewardCheckpoint)
+		log.Warn("[XDPoSConfigEqual] RewardCheckpoint mismatch", "a.RewardCheckpoint", a.RewardCheckpoint, "b.RewardCheckpoint", b.RewardCheckpoint)
 		return false
 	}
 	if a.Gap != b.Gap {
-		log.Info("[XDPoSConfigEqual] Gap mismatch", "a.Gap", a.Gap, "b.Gap", b.Gap)
+		log.Warn("[XDPoSConfigEqual] Gap mismatch", "a.Gap", a.Gap, "b.Gap", b.Gap)
 		return false
 	}
 	if a.FoudationWalletAddr != b.FoudationWalletAddr {
-		log.Info("[XDPoSConfigEqual] FoudationWalletAddr mismatch", "a.FoudationWalletAddr", a.FoudationWalletAddr.Hex(), "b.FoudationWalletAddr", b.FoudationWalletAddr.Hex())
+		log.Warn("[XDPoSConfigEqual] FoudationWalletAddr mismatch", "a.FoudationWalletAddr", a.FoudationWalletAddr.Hex(), "b.FoudationWalletAddr", b.FoudationWalletAddr.Hex())
 		return false
 	}
 	if a.SkipV1Validation != b.SkipV1Validation {
-		log.Info("[XDPoSConfigEqual] SkipV1Validation mismatch", "a.SkipV1Validation", a.SkipV1Validation, "b.SkipV1Validation", b.SkipV1Validation)
+		log.Warn("[XDPoSConfigEqual] SkipV1Validation mismatch", "a.SkipV1Validation", a.SkipV1Validation, "b.SkipV1Validation", b.SkipV1Validation)
 		return false
 	}
-
-	v2Equal := V2Equal(a.V2, b.V2)
-	if !v2Equal {
-		log.Info("[XDPoSConfigEqual] V2 configs not equal")
-	}
-	return v2Equal
+	return V2Equal(a.V2, b.V2)
 }
 
 func V2Equal(a, b *V2) bool {
 	if a == nil || b == nil {
-		log.Info("[V2Equal] Nil check", "a", a, "b", b, "equal", a == b)
-		return a == b
+		if a != b {
+			log.Warn("[V2Equal] One of the configs is nil", "a", a, "b", b)
+			return false
+		}
+		return true
 	}
-	if a.SwitchEpoch != b.SwitchEpoch || !configNumEqual(a.SwitchBlock, b.SwitchBlock) || !slices.Equal(a.configIndex, b.configIndex) {
+	if a.SwitchEpoch != b.SwitchEpoch {
+		log.Warn("[V2Equal] SwitchEpoch mismatch", "a.SwitchEpoch", a.SwitchEpoch, "b.SwitchEpoch", b.SwitchEpoch)
 		return false
 	}
-	// compare AllConfigs according to smaller map
-	smallerMap, largerMap := a.AllConfigs, b.AllConfigs
-	if len(smallerMap) > len(largerMap) {
-		smallerMap, largerMap = largerMap, smallerMap
+	if !configNumEqual(a.SwitchBlock, b.SwitchBlock) {
+		log.Warn("[V2Equal] SwitchBlock mismatch", "a.SwitchBlock", a.SwitchBlock, "b.SwitchBlock", b.SwitchBlock)
+		return false
 	}
-	for key, cfg1 := range smallerMap {
-		cfg2, ok := largerMap[key]
-		if !ok || !V2ConfigEqual(cfg1, cfg2) {
-			return false
+	// Only check configs in both of AllConfigs
+	for k1, cfg1 := range a.AllConfigs {
+		if cfg2, ok := b.AllConfigs[k1]; ok {
+			if !V2ConfigEqual(cfg1, cfg2) {
+				return false
+			}
 		}
 	}
 	return true
@@ -553,10 +554,25 @@ func V2Equal(a, b *V2) bool {
 
 func V2ConfigEqual(a, b *V2Config) bool {
 	if a == nil || b == nil {
-		log.Info("[V2ConfigEqual] Nil check", "a", a, "b", b, "equal", a == b)
-		return a == b
+		if a != b {
+			log.Warn("[V2ConfigEqual] One of the configs is nil", "a", a, "b", b)
+			return false
+		}
+		return true
 	}
-	return a.MaxMasternodes == b.MaxMasternodes && a.SwitchRound == b.SwitchRound && a.CertThreshold == b.CertThreshold
+	if a.MaxMasternodes != b.MaxMasternodes {
+		log.Warn("[V2ConfigEqual] MaxMasternodes mismatch", "a.MaxMasternodes", a.MaxMasternodes, "b.MaxMasternodes", b.MaxMasternodes)
+		return false
+	}
+	if a.SwitchRound != b.SwitchRound {
+		log.Warn("[V2ConfigEqual] SwitchRound mismatch", "a.SwitchRound", a.SwitchRound, "b.SwitchRound", b.SwitchRound)
+		return false
+	}
+	if a.CertThreshold != b.CertThreshold {
+		log.Warn("[V2ConfigEqual] CertThreshold mismatch", "a.CertThreshold", a.CertThreshold, "b.CertThreshold", b.CertThreshold)
+		return false
+	}
+	return true
 }
 
 func (c *XDPoSConfig) String() string {


### PR DESCRIPTION
# Proposed changes

`configIndex`  is the keys of `AllConfigs`, we should skip compare a.configIndex and b.configIndex after upgrade.

<img width="1280" height="199" alt="image" src="https://github.com/user-attachments/assets/f1db4676-85a0-401e-a4d1-7c679f8e514a" />


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
