### PR TITLE
chore: remove SwitchEpoch comparation

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -533,10 +533,6 @@ func V2Equal(a, b *V2) bool {
 		}
 		return true
 	}
-	if a.SwitchEpoch != b.SwitchEpoch {
-		log.Warn("[V2Equal] SwitchEpoch mismatch", "a.SwitchEpoch", a.SwitchEpoch, "b.SwitchEpoch", b.SwitchEpoch)
-		return false
-	}
 	if !configNumEqual(a.SwitchBlock, b.SwitchBlock) {
 		log.Warn("[V2Equal] SwitchBlock mismatch", "a.SwitchBlock", a.SwitchBlock, "b.SwitchBlock", b.SwitchBlock)
 		return false

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 2        // Major version component of the current release
 	VersionMinor = 6        // Minor version component of the current release
-	VersionPatch = 7        // Patch version component of the current release
+	VersionPatch = 8        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
# Proposed changes
remove SwitchEpoch comparison, because 1) the old version doesn't have this field, 2) it is calculated result from SwitchBlock, so it's not necessary to compare SwitchEpoch.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [x] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
