### PR TITLE
eth/hooks: fix missing `nil` check, close XFN-114 #1695

### DIFF
--- a/eth/hooks/engine_v2_hooks.go
+++ b/eth/hooks/engine_v2_hooks.go
@@ -48,12 +48,12 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		for i := uint64(1); ; i++ {
 			parentHeader := chain.GetHeader(parentHash, parentNumber)
 			if parentHeader == nil {
-				log.Error("[HookPenalty] fail to get parent header")
+				log.Error("[V2 HookPenalty] fail to get parent header")
 				return []common.Address{}, fmt.Errorf("hook penalty fail to get parent header at number: %v, hash: %v", parentNumber, parentHash)
 			}
 			isEpochSwitch, _, err := adaptor.EngineV2.IsEpochSwitch(parentHeader)
 			if err != nil {
-				log.Error("[HookPenalty] isEpochSwitch", "err", err)
+				log.Error("[V2 HookPenalty] isEpochSwitch", "err", err)
 				return []common.Address{}, err
 			}
 			if isEpochSwitch {
@@ -76,13 +76,13 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		penalties := []common.Address{}
 		for miner, total := range statMiners {
 			if total < common.MinimunMinerBlockPerEpoch {
-				log.Info("[HookPenalty] Find a node does not create enough block", "addr", miner.Hex(), "total", total, "require", common.MinimunMinerBlockPerEpoch)
+				log.Info("[V2 HookPenalty] Find a node does not create enough block", "addr", miner.Hex(), "total", total, "require", common.MinimunMinerBlockPerEpoch)
 				penalties = append(penalties, miner)
 			}
 		}
 		for _, addr := range preMasternodes {
 			if _, exist := statMiners[addr]; !exist {
-				log.Info("[HookPenalty] Find a node do not create any block", "addr", addr.Hex())
+				log.Info("[V2 HookPenalty] Find a node do not create any block", "addr", addr.Hex())
 				penalties = append(penalties, addr)
 			}
 		}
@@ -96,7 +96,7 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 			for _, p := range pens {
 				for _, addr := range candidates {
 					if p == addr {
-						log.Info("[HookPenalty] get previous penalty node and add into comeback list", "addr", addr)
+						log.Info("[V2 HookPenalty] get previous penalty node and add into comeback list", "addr", addr)
 						penComebacks = append(penComebacks, p)
 						break
 					}
@@ -123,8 +123,12 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 			signingTxs, ok := adaptor.GetCachedSigningTxs(bhash)
 			if !ok {
 				block := chain.GetBlock(bhash, blockNumber)
-				txs := block.Transactions()
-				signingTxs = adaptor.CacheSigningTxs(bhash, txs)
+				if block != nil {
+					txs := block.Transactions()
+					signingTxs = adaptor.CacheSigningTxs(bhash, txs)
+				} else {
+					log.Debug("[V2 HookPenalty] block not found when retrieving signing transactions", "hash", bhash, "number", blockNumber)
+				}
 			}
 			// Check signer signed?
 			for _, tx := range signingTxs {
@@ -156,9 +160,9 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		}
 
 		for i, p := range penalties {
-			log.Info("[HookPenalty] Final penalty list", "index", i, "addr", p)
+			log.Info("[V2 HookPenalty] Final penalty list", "index", i, "addr", p)
 		}
-		log.Info("[HookPenalty] Time Calculated HookPenaltyV2 ", "block", number, "time", common.PrettyDuration(time.Since(start)))
+		log.Info("[V2 HookPenalty] Time Calculated HookPenaltyV2 ", "block", number, "time", common.PrettyDuration(time.Since(start)))
 		return penalties, nil
 	}
 
@@ -237,7 +241,12 @@ func GetSigningTxCount(c *XDPoS.XDPoS, chain consensus.ChainReader, header *type
 	var masternodes []common.Address
 	var startBlockNumber, endBlockNumber uint64
 	for i := number - 1; ; i-- {
-		header = chain.GetHeader(header.ParentHash, i)
+		parentHash := header.ParentHash
+		header = chain.GetHeader(parentHash, i)
+		if header == nil {
+			log.Error("[GetSigningTxCount] fail to get header", "number", i, "hash", parentHash)
+			return nil, fmt.Errorf("fail to get header in GetSigningTxCount at number: %v, hash: %v", i, parentHash)
+		}
 		isEpochSwitch, _, err := c.IsEpochSwitch(header)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Proposed changes

pick some missing codes from #1695

```text
xinfinnetwork_1  | panic: runtime error: invalid memory address or nil pointer dereference
xinfinnetwork_1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x65d5e0]
xinfinnetwork_1  |
xinfinnetwork_1  | goroutine 118729 [running]:
xinfinnetwork_1  | github.com/XinFinOrg/XDPoSChain/core/types.(*Block).Transactions(0x4bee88083292c1d2?)
xinfinnetwork_1  |      /builder/core/types/block.go:341
xinfinnetwork_1  | github.com/XinFinOrg/XDPoSChain/eth.New.AttachConsensusV2Hooks.func6({0x182ad68, 0xc000330630}, 0xc013d4c900, {0xce, 0x50, 0xd, 0xec, 0x82, 0x7e, 0xc6, ...}, ...)
xinfinnetwork_1  |      /builder/eth/hooks/engine_v2_hooks.go:126 +0xf77
xinfinnetwork_1  | github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2.(*XDPoS_v2).calcMasternodes(0xc0001be2c0, {0x182ad68, 0xc000330630}, 0xc013d4c900, {0xb, 0x1c, 0xea, 0xa7, 0x47, 0xa5, ...}, ...)
xinfinnetwork_1  |      /builder/consensus/XDPoS/engines/engine_v2/engine.go:1117 +0x188
xinfinnetwork_1  | github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2.(*XDPoS_v2).verifyHeader(0xc0001be2c0, {0x182ad68, 0xc000330630}, 0xc0135ca508, {0xc01a6dceb0, 0x0, 0x1cea2b7668?}, 0x1)
xinfinnetwork_1  |      /builder/consensus/XDPoS/engines/engine_v2/verifyHeader.go:135 +0xd97
xinfinnetwork_1  | github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2.(*XDPoS_v2).VerifyHeaders.func1()
xinfinnetwork_1  |      /builder/consensus/XDPoS/engines/engine_v2/engine.go:585 +0x136
xinfinnetwork_1  | created by github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2.(*XDPoS_v2).VerifyHeaders in goroutine 7852
xinfinnetwork_1  |      /builder/consensus/XDPoS/engines/engine_v2/engine.go:583 +0x105
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
