### PR TITLE
common/bitutil: deprecate XORBytes in favor of stdlib crypto/subtle #33331

### DIFF
--- a/common/bitutil/bitutil.go
+++ b/common/bitutil/bitutil.go
@@ -8,6 +8,7 @@
 package bitutil
 
 import (
+	"crypto/subtle"
 	"runtime"
 	"unsafe"
 )
@@ -17,46 +18,16 @@ const supportsUnaligned = runtime.GOARCH == "386" || runtime.GOARCH == "amd64" |
 
 // XORBytes xors the bytes in a and b. The destination is assumed to have enough
 // space. Returns the number of bytes xor'd.
+//
+// If dst does not have length at least n,
+// XORBytes panics without writing anything to dst.
+//
+// dst and x or y may overlap exactly or not at all,
+// otherwise XORBytes may panic.
+//
+// Deprecated: use crypto/subtle.XORBytes
 func XORBytes(dst, a, b []byte) int {
-	if supportsUnaligned {
-		return fastXORBytes(dst, a, b)
-	}
-	return safeXORBytes(dst, a, b)
-}
-
-// fastXORBytes xors in bulk. It only works on architectures that support
-// unaligned read/writes.
-func fastXORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
-	w := n / wordSize
-	if w > 0 {
-		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
-		aw := *(*[]uintptr)(unsafe.Pointer(&a))
-		bw := *(*[]uintptr)(unsafe.Pointer(&b))
-		for i := 0; i < w; i++ {
-			dw[i] = aw[i] ^ bw[i]
-		}
-	}
-	for i := n - n%wordSize; i < n; i++ {
-		dst[i] = a[i] ^ b[i]
-	}
-	return n
-}
-
-// safeXORBytes xors one by one. It works on all architectures, independent if
-// it supports unaligned read/writes or not.
-func safeXORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
-	for i := 0; i < n; i++ {
-		dst[i] = a[i] ^ b[i]
-	}
-	return n
+	return subtle.XORBytes(dst, a, b)
 }
 
 // ANDBytes ands the bytes in a and b. The destination is assumed to have enough

--- a/common/bitutil/bitutil_test.go
+++ b/common/bitutil/bitutil_test.go
@@ -29,13 +29,25 @@ func TestXOR(t *testing.T) {
 				d2 := make([]byte, 1023+alignD)[alignD:]
 
 				XORBytes(d1, p, q)
-				safeXORBytes(d2, p, q)
+				naiveXOR(d2, p, q)
 				if !bytes.Equal(d1, d2) {
 					t.Error("not equal", d1, d2)
 				}
 			}
 		}
 	}
+}
+
+// naiveXOR xors bytes one by one.
+func naiveXOR(dst, a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		dst[i] = a[i] ^ b[i]
+	}
+	return n
 }
 
 // Tests that bitwise AND works for various alignments.
@@ -134,7 +146,7 @@ func benchmarkBaseXOR(b *testing.B, size int) {
 	p, q := make([]byte, size), make([]byte, size)
 
 	for i := 0; i < b.N; i++ {
-		safeXORBytes(p, p, q)
+		naiveXOR(p, p, q)
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

Ref: #33331

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
