### PR TITLE
perf(all): use `big.Int.Sign()` to compare with 0

### DIFF
--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -390,7 +390,7 @@ func (x *XDPoS_v1) GetCurrentEpochSwitchBlock(blockNumber *big.Int) (uint64, uin
 func (x *XDPoS_v1) GetPeriod() uint64 { return x.config.Period }
 
 func (x *XDPoS_v1) whoIsCreator(snap *SnapshotV1, header *types.Header) (common.Address, error) {
-	if header.Number.Uint64() == 0 {
+	if header.Number.Sign() == 0 {
 		return common.Address{}, errors.New("don't take block 0")
 	}
 	m, err := ecrecover(header, snap.sigcache)
@@ -446,7 +446,7 @@ func (x *XDPoS_v1) yourTurn(chain consensus.ChainReader, parent *types.Header, s
 	pre := common.Address{}
 	// masternode[0] has chance to create block 1
 	preIndex := -1
-	if parent.Number.Uint64() != 0 {
+	if parent.Number.Sign() != 0 {
 		pre, err = x.whoIsCreator(snap, parent)
 		if err != nil {
 			return 0, 0, 0, false, err

--- a/consensus/XDPoS/engines/engine_v2/epochSwitch.go
+++ b/consensus/XDPoS/engines/engine_v2/epochSwitch.go
@@ -36,7 +36,7 @@ func (x *XDPoS_v2) getEpochSwitchInfo(chain consensus.ChainReader, header *types
 	}
 	if isEpochSwitch {
 		log.Debug("[getEpochSwitchInfo] header is epoch switch", "hash", hash.Hex(), "number", h.Number.Uint64())
-		if h.Number.Uint64() == 0 {
+		if h.Number.Sign() == 0 {
 			log.Warn("[getEpochSwitchInfo] block 0, init epoch differently")
 			// handle genesis block differently as follows
 			masternodes := common.ExtractAddressFromBytes(h.Extra[32 : len(h.Extra)-65])

--- a/consensus/XDPoS/engines/engine_v2/verifyHeader.go
+++ b/consensus/XDPoS/engines/engine_v2/verifyHeader.go
@@ -62,7 +62,7 @@ func (x *XDPoS_v2) verifyHeader(chain consensus.ChainReader, header *types.Heade
 
 	// Ensure gas limit is consistent with parent
 	err := misc.VerifyGaslimit(parent.GasLimit, header.GasLimit)
-	if err != nil && parent.Number.Uint64() != 0 { // skip genesis block
+	if err != nil && parent.Number.Sign() != 0 { // skip genesis block
 		return err
 	}
 	// Ensure gas used is less than or equal to gas limit

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -439,7 +439,7 @@ func testReorg(t *testing.T, first, second []int64, td int64, full bool) {
 		}
 	} else {
 		prev := blockchain.CurrentHeader()
-		for header := blockchain.GetHeaderByNumber(blockchain.CurrentHeader().Number.Uint64() - 1); header.Number.Uint64() != 0; prev, header = header, blockchain.GetHeaderByNumber(header.Number.Uint64()-1) {
+		for header := blockchain.GetHeaderByNumber(blockchain.CurrentHeader().Number.Uint64() - 1); header.Number.Sign() != 0; prev, header = header, blockchain.GetHeaderByNumber(header.Number.Uint64()-1) {
 			if prev.ParentHash != header.Hash() {
 				t.Errorf("parent header hash mismatch: have %x, want %x", prev.ParentHash, header.Hash())
 			}

--- a/crypto/bn256/google/bn256_test.go
+++ b/crypto/bn256/google/bn256_test.go
@@ -22,7 +22,7 @@ func TestGFp2Invert(t *testing.T) {
 	inv.Invert(a, pool)
 
 	b := newGFp2(pool).Mul(inv, a, pool)
-	if b.x.Int64() != 0 || b.y.Int64() != 1 {
+	if b.x.Sign() != 0 || b.y.Cmp(big.NewInt(1)) != 0 {
 		t.Fatalf("bad result for a^-1*a: %s %s", b.x, b.y)
 	}
 
@@ -36,11 +36,11 @@ func TestGFp2Invert(t *testing.T) {
 }
 
 func isZero(n *big.Int) bool {
-	return new(big.Int).Mod(n, P).Int64() == 0
+	return new(big.Int).Mod(n, P).Sign() == 0
 }
 
 func isOne(n *big.Int) bool {
-	return new(big.Int).Mod(n, P).Int64() == 1
+	return new(big.Int).Mod(n, P).Cmp(big.NewInt(1)) == 0
 }
 
 func TestGFp6Invert(t *testing.T) {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -363,10 +363,10 @@ func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []comm
 	var ret []*types.Log
 Logs:
 	for _, log := range logs {
-		if fromBlock != nil && fromBlock.Int64() >= 0 && fromBlock.Uint64() > log.BlockNumber {
+		if fromBlock != nil && fromBlock.Sign() >= 0 && fromBlock.Uint64() > log.BlockNumber {
 			continue
 		}
-		if toBlock != nil && toBlock.Int64() >= 0 && toBlock.Uint64() < log.BlockNumber {
+		if toBlock != nil && toBlock.Sign() >= 0 && toBlock.Uint64() < log.BlockNumber {
 			continue
 		}
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -152,7 +152,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		lendingTxSub:   nil,
 	}
 	// Figure out whether to allow fast sync or not
-	if mode == downloader.FastSync && blockchain.CurrentBlock().Number.Uint64() > 0 {
+	if mode == downloader.FastSync && blockchain.CurrentBlock().Number.Sign() > 0 {
 		log.Warn("Blockchain not empty, fast sync disabled")
 		mode = downloader.FullSync
 	}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -184,7 +184,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if atomic.LoadUint32(&pm.snapSync) == 1 {
 		// Fast sync was explicitly requested, and explicitly granted
 		mode = downloader.FastSync
-	} else if currentBlock.Number.Uint64() == 0 && pm.blockchain.CurrentSnapBlock().Number.Uint64() > 0 {
+	} else if currentBlock.Number.Sign() == 0 && pm.blockchain.CurrentSnapBlock().Number.Sign() > 0 {
 		// The database seems empty as the current block is the genesis. Yet the fast
 		// block is ahead, so fast sync was enabled for this node at a certain point.
 		// The only scenario where this can happen is if the user manually (or via a

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -763,7 +763,7 @@ func (api *BlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, blockNum
 // GetMasternodes returns masternodes set at the starting block of epoch of the given block
 func (api *BlockChainAPI) GetMasternodes(ctx context.Context, b *types.Block) ([]common.Address, error) {
 	var masternodes []common.Address
-	if b.Number().Int64() >= 0 {
+	if b.Number().Sign() >= 0 {
 		curBlockNumber := b.Number().Uint64()
 		prevBlockNumber := curBlockNumber + (common.MergeSignRange - (curBlockNumber % common.MergeSignRange))
 		latestBlockNumber := api.b.CurrentBlock().Number.Uint64()
@@ -1499,7 +1499,7 @@ func (api *BlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Block, i
 
 // findNearestSignedBlock finds the nearest checkpoint from input block
 func (api *BlockChainAPI) findNearestSignedBlock(ctx context.Context, b *types.Block) *types.Block {
-	if b.Number().Int64() <= 0 {
+	if b.Number().Sign() <= 0 {
 		return nil
 	}
 

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -286,7 +286,7 @@ func (t *BlockTest) validateImportedHeaders(cm *core.BlockChain, validBlocks []b
 	// block-by-block, so we can only validate imported headers after
 	// all blocks have been processed by BlockChain, as they may not
 	// be part of the longest chain until last block is imported.
-	for b := cm.CurrentBlock(); b != nil && b.Number.Uint64() != 0; b = cm.GetHeaderByHash(b.ParentHash) {
+	for b := cm.CurrentBlock(); b != nil && b.Number.Sign() != 0; b = cm.GetHeaderByHash(b.ParentHash) {
 		if err := validateHeader(bmap[b.Hash()].BlockHeader, b); err != nil {
 			return fmt.Errorf("imported block header validation failed: %v", err)
 		}


### PR DESCRIPTION
# Proposed changes

- `Sign()` is more more efficient
- `Uint64()` and `.Int64()` maybe overflow

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
