### PR TITLE
common/countdown: format exp_duration.go to fix goimports warning

### DIFF
--- a/common/countdown/exp_duration.go
+++ b/common/countdown/exp_duration.go
@@ -42,7 +42,7 @@ func (d *ExpTimeoutDuration) GetTimeoutDuration(currentRound, highestRound types
 	power := float64(1)
 	// below statement must be true, just to prevent negative result
 	if highestRound < currentRound {
-		exp := min(uint8(currentRound-highestRound) - 1, d.maxExponent)
+		exp := min(uint8(currentRound-highestRound)-1, d.maxExponent)
 		power = math.Pow(d.base, float64(exp))
 	}
 	return d.duration * time.Duration(power)


### PR DESCRIPTION
# Proposed changes

Fix goimports warning:

```text
common/countdown/exp_duration.go:45:1: File is not properly formatted (goimports)
                exp := min(uint8(currentRound-highestRound) - 1, d.maxExponent)
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
