### PR TITLE
core/types: fix panic on invalid signature length #33647

### DIFF
--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -135,3 +135,28 @@ func TestChainId(t *testing.T) {
 		t.Error("expected no error")
 	}
 }
+
+func TestSignatureValuesError(t *testing.T) {
+	// 1. Setup a valid transaction
+	tx := NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil)
+	signer := HomesteadSigner{}
+
+	// 2. Call WithSignature with invalid length sig (not 65 bytes)
+	invalidSig := make([]byte, 64)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Panicked for invalid signature length, expected error: %v", r)
+			}
+		}()
+		_, err := tx.WithSignature(signer, invalidSig)
+		if err == nil {
+			t.Fatal("Expected error for invalid signature length, got nil")
+		} else {
+			// This is just a sanity check to ensure we got an error,
+			// the exact error message is verified in unit tests elsewhere if needed.
+			t.Logf("Got expected error: %v", err)
+		}
+	}()
+}

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -94,7 +94,10 @@ func SignSetCode(prv *ecdsa.PrivateKey, auth SetCodeAuthorization) (SetCodeAutho
 	if err != nil {
 		return SetCodeAuthorization{}, err
 	}
-	r, s, _ := decodeSignature(sig)
+	r, s, _, err := decodeSignature(sig)
+	if err != nil {
+		return SetCodeAuthorization{}, err
+	}
 	return SetCodeAuthorization{
 		ChainID: auth.ChainID,
 		Address: auth.Address,


### PR DESCRIPTION
# Proposed changes

Replace panic with error return in decodeSignature to prevent crashes on invalid inputs, and update callers to propagate the error.

Ref: #33647

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
