### PR TITLE
perf(node, p2p): avoid unnecessary check len of map

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -72,10 +72,8 @@ func (api *adminAPI) AddPeer(url string) (bool, error) {
 		}
 	}
 	// reject the node which is in peer blacklist
-	if len(server.BlackPeers) > 0 {
-		if _, ok := server.BlackPeers[node.ID]; ok {
-			return false, fmt.Errorf("peer is in blacklist: %v, ID: %s", url, node.ID)
-		}
+	if _, ok := server.BlackPeers[node.ID]; ok {
+		return false, fmt.Errorf("peer is in blacklist: %v, ID: %s", url, node.ID)
 	}
 	server.AddPeer(node)
 	return true, nil
@@ -115,10 +113,8 @@ func (api *adminAPI) AddTrustedPeer(url string) (bool, error) {
 		}
 	}
 	// reject the node which is in peer blacklist
-	if len(server.BlackPeers) > 0 {
-		if _, ok := server.BlackPeers[node.ID]; ok {
-			return false, fmt.Errorf("trusted peer is in blacklist: %v, ID: %s", url, node.ID)
-		}
+	if _, ok := server.BlackPeers[node.ID]; ok {
+		return false, fmt.Errorf("trusted peer is in blacklist: %v, ID: %s", url, node.ID)
 	}
 	server.AddTrustedPeer(node)
 	return true, nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -905,11 +905,9 @@ func (srv *Server) setupConn(c *conn, flags connFlag, dialDest *discover.Node) e
 			return DiscNonWhitelistedPeer
 		}
 	}
-	if len(srv.BlackPeers) > 0 {
-		if _, ok := srv.BlackPeers[c.id]; ok {
-			clog.Debug("Reject blacklisted peer")
-			return DiscBlacklistedPeer
-		}
+	if _, ok := srv.BlackPeers[c.id]; ok {
+		clog.Debug("Reject blacklisted peer")
+		return DiscBlacklistedPeer
 	}
 	// For dialed connections, check that the remote public key matches.
 	if dialDest != nil && c.id != dialDest.ID {


### PR DESCRIPTION
# Proposed changes

Even if the map is not initialized, we can use map[key] to check if the key is in map directly.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
