### PR TITLE
fix(node): fix data race on httpConfig.prefix #32047

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -62,6 +62,7 @@ type rpcEndpointConfig struct {
 
 type rpcHandler struct {
 	http.Handler
+	prefix string
 	server *rpc.Server
 }
 
@@ -76,11 +77,11 @@ type httpServer struct {
 
 	// HTTP RPC handler things.
 	httpConfig  httpConfig
-	httpHandler atomic.Value // *rpcHandler
+	httpHandler atomic.Pointer[rpcHandler]
 
 	// WebSocket handler things.
 	wsConfig  wsConfig
-	wsHandler atomic.Value // *rpcHandler
+	wsHandler atomic.Pointer[rpcHandler]
 
 	// These are set by setListenAddr.
 	endpoint string
@@ -96,8 +97,6 @@ const (
 
 func newHTTPServer(log log.Logger, timeouts rpc.HTTPTimeouts) *httpServer {
 	h := &httpServer{log: log, timeouts: timeouts, handlerNames: make(map[string]string)}
-	h.httpHandler.Store((*rpcHandler)(nil))
-	h.wsHandler.Store((*rpcHandler)(nil))
 	return h
 }
 
@@ -197,16 +196,16 @@ func (h *httpServer) start() error {
 
 func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// check if ws request and serve if ws enabled
-	ws := h.wsHandler.Load().(*rpcHandler)
+	ws := h.wsHandler.Load()
 	if ws != nil && isWebsocket(r) {
-		if checkPath(r, h.wsConfig.prefix) {
+		if checkPath(r, ws.prefix) {
 			ws.ServeHTTP(w, r)
 		}
 		return
 	}
 
 	// if http-rpc is enabled, try to serve request
-	rpc := h.httpHandler.Load().(*rpcHandler)
+	rpc := h.httpHandler.Load()
 	if rpc != nil {
 		// First try to route in the mux.
 		// Requests to a path below root are handled by the mux,
@@ -218,7 +217,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if checkPath(r, h.httpConfig.prefix) {
+		if checkPath(r, rpc.prefix) {
 			rpc.ServeHTTP(w, r)
 			return
 		}
@@ -266,14 +265,14 @@ func (h *httpServer) doStop() {
 	}
 
 	// Shut down the server.
-	httpHandler := h.httpHandler.Load().(*rpcHandler)
-	wsHandler := h.wsHandler.Load().(*rpcHandler)
+	httpHandler := h.httpHandler.Load()
+	wsHandler := h.wsHandler.Load()
 	if httpHandler != nil {
-		h.httpHandler.Store((*rpcHandler)(nil))
+		h.httpHandler.Store(nil)
 		httpHandler.server.Stop()
 	}
 	if wsHandler != nil {
-		h.wsHandler.Store((*rpcHandler)(nil))
+		h.wsHandler.Store(nil)
 		wsHandler.server.Stop()
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
@@ -312,6 +311,7 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 	h.httpConfig = config
 	h.httpHandler.Store(&rpcHandler{
 		Handler: NewHTTPHandlerStack(srv, config.CorsAllowedOrigins, config.Vhosts, config.jwtSecret),
+		prefix:  config.prefix,
 		server:  srv,
 	})
 	return nil
@@ -319,9 +319,9 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 
 // disableRPC stops the HTTP RPC handler. This is internal, the caller must hold h.mu.
 func (h *httpServer) disableRPC() bool {
-	handler := h.httpHandler.Load().(*rpcHandler)
+	handler := h.httpHandler.Load()
 	if handler != nil {
-		h.httpHandler.Store((*rpcHandler)(nil))
+		h.httpHandler.Store(nil)
 		handler.server.Stop()
 	}
 	return handler != nil
@@ -348,6 +348,7 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig) error {
 	h.wsConfig = config
 	h.wsHandler.Store(&rpcHandler{
 		Handler: NewWSHandlerStack(srv.WebsocketHandler(config.Origins), config.jwtSecret),
+		prefix:  config.prefix,
 		server:  srv,
 	})
 	return nil
@@ -367,9 +368,9 @@ func (h *httpServer) stopWS() {
 
 // disableWS disables the WebSocket handler. This is internal, the caller must hold h.mu.
 func (h *httpServer) disableWS() bool {
-	ws := h.wsHandler.Load().(*rpcHandler)
+	ws := h.wsHandler.Load()
 	if ws != nil {
-		h.wsHandler.Store((*rpcHandler)(nil))
+		h.wsHandler.Store(nil)
 		ws.server.Stop()
 	}
 	return ws != nil
@@ -377,12 +378,12 @@ func (h *httpServer) disableWS() bool {
 
 // rpcAllowed returns true when JSON-RPC over HTTP is enabled.
 func (h *httpServer) rpcAllowed() bool {
-	return h.httpHandler.Load().(*rpcHandler) != nil
+	return h.httpHandler.Load() != nil
 }
 
 // wsAllowed returns true when JSON-RPC over WebSocket is enabled.
 func (h *httpServer) wsAllowed() bool {
-	return h.wsHandler.Load().(*rpcHandler) != nil
+	return h.wsHandler.Load() != nil
 }
 
 // isWebsocket checks the header of an http request for a websocket upgrade request.


### PR DESCRIPTION
# Proposed changes

This fixes a data race when accessing the `httpConfig.prefix` field. This field can be modified while the server is running through `enableRPC`. The fix is storing the prefix in the handler, which is accessed through the atomic pointer.

Ref: #32047

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
