### PR TITLE
fix(common): fix race condition in countdown timer StopTimer method

### DIFF
--- a/common/countdown/countdown.go
+++ b/common/countdown/countdown.go
@@ -64,14 +64,15 @@ func (t *CountdownTimer) Reset(i interface{}, currentRound, highestRound types.R
 
 // A long running process that
 func (t *CountdownTimer) startTimer(i interface{}, currentRound, highestRound types.Round) {
-	// Make sure we mark Initilised to false when we quit the countdown
-	defer t.setInitilised(false)
 	timer := time.NewTimer(t.durationHelper.GetTimeoutDuration(currentRound, highestRound))
 	// We start with a inf loop
 	for {
 		select {
 		case q := <-t.quitc:
 			log.Debug("Quit countdown timer")
+			// Set initilised to false before signaling completion
+			// This ensures the state is updated before StopTimer() returns
+			t.setInitilised(false)
 			close(q)
 			return
 		case <-timer.C:


### PR DESCRIPTION
# Proposed changes

The TestCountdownShouldBeAbleToStop test was failing intermittently due to a race condition in the StopTimer() implementation. Previously, the goroutine used defer to set initilised=false, which executed after close(q) signaled completion to StopTimer(). This allowed StopTimer() to return before the state was properly cleaned up, causing isInitilised() checks to occasionally see stale true values.

Fixed by explicitly calling setInitilised(false) before close(q), ensuring the state is updated atomically before StopTimer() returns. This eliminates the race condition and makes the test pass consistently.

Verified by running the test 30 times consecutively with no failures.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
