### PR TITLE
fix(accounts): not use magic numbers for rpc.BlockNumber

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -830,11 +830,11 @@ func (b *SimulatedBackend) FilterLogs(ctx context.Context, query ethereum.Filter
 		filter = b.filterSystem.NewBlockFilter(*query.BlockHash, query.Addresses, query.Topics)
 	} else {
 		// Initialize unset filter boundaried to run from genesis to chain head
-		from := int64(0)
+		from := rpc.EarliestBlockNumber.Int64()
 		if query.FromBlock != nil {
 			from = query.FromBlock.Int64()
 		}
-		to := int64(-1)
+		to := rpc.LatestBlockNumber.Int64()
 		if query.ToBlock != nil {
 			to = query.ToBlock.Int64()
 		}


### PR DESCRIPTION
# Proposed changes

We change `LatestEpochNumber` from `-1` to `-2` in PR #992 according to geth. But the constants are not updated in file `accounts/abi/bind/backends/simulated.go`. And we will change `EarliestBlockNumber` from `0` to `-5` later as geth #31361.   

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
