### PR TITLE
test(params): move params.V2TestsGasLimit to engine_v2_tests package

### DIFF
--- a/consensus/tests/engine_v2_tests/helper.go
+++ b/consensus/tests/engine_v2_tests/helper.go
@@ -37,6 +37,8 @@ type signersList map[string]bool
 
 const GAP = int(450)
 
+const testGasLimit uint64 = 1200000000 // The gas limit used in the v2 consensus tests
+
 var (
 	acc1Key, _  = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
 	acc2Key, _  = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
@@ -872,7 +874,7 @@ func createBlockFromHeader(bc *core.BlockChain, customHeader *types.Header, txs 
 		Coinbase:    customHeader.Coinbase,
 		Difficulty:  difficulty,
 		Number:      customHeader.Number,
-		GasLimit:    params.V2TestsGasLimit,
+		GasLimit:    testGasLimit,
 		Time:        uint64(time.Now().Unix() - 1000000 + int64(customHeader.Number.Uint64()*10)),
 		Extra:       customHeader.Extra,
 		Validator:   customHeader.Validator,

--- a/consensus/tests/engine_v2_tests/mine_test.go
+++ b/consensus/tests/engine_v2_tests/mine_test.go
@@ -150,7 +150,7 @@ func TestPrepareFail(t *testing.T) {
 	notReadyToProposeHeader := &types.Header{
 		ParentHash: currentBlock.Hash(),
 		Number:     big.NewInt(int64(901)),
-		GasLimit:   params.V2TestsGasLimit,
+		GasLimit:   testGasLimit,
 		Time:       tstamp,
 		Coinbase:   signer,
 	}
@@ -161,7 +161,7 @@ func TestPrepareFail(t *testing.T) {
 	notReadyToMine := &types.Header{
 		ParentHash: currentBlock.Hash(),
 		Number:     big.NewInt(int64(901)),
-		GasLimit:   params.V2TestsGasLimit,
+		GasLimit:   testGasLimit,
 		Time:       tstamp,
 		Coinbase:   signer,
 	}
@@ -175,7 +175,7 @@ func TestPrepareFail(t *testing.T) {
 	header901WithoutCoinbase := &types.Header{
 		ParentHash: currentBlock.Hash(),
 		Number:     big.NewInt(int64(901)),
-		GasLimit:   params.V2TestsGasLimit,
+		GasLimit:   testGasLimit,
 		Time:       tstamp,
 	}
 
@@ -196,7 +196,7 @@ func TestPrepareHappyPath(t *testing.T) {
 	header901 := &types.Header{
 		ParentHash: currentBlock.Hash(),
 		Number:     big.NewInt(int64(901)),
-		GasLimit:   params.V2TestsGasLimit,
+		GasLimit:   testGasLimit,
 		Time:       tstamp,
 		Coinbase:   signer,
 	}
@@ -276,7 +276,7 @@ func TestUpdateMultipleMasterNodes(t *testing.T) {
 	header1800 := &types.Header{
 		ParentHash: parentBlock.Hash(),
 		Number:     big.NewInt(int64(1800)),
-		GasLimit:   params.V2TestsGasLimit,
+		GasLimit:   testGasLimit,
 		Time:       tstamp,
 		Coinbase:   voterAddr,
 	}

--- a/consensus/tests/engine_v2_tests/penalty_test.go
+++ b/consensus/tests/engine_v2_tests/penalty_test.go
@@ -49,7 +49,7 @@ func TestHookPenaltyV2Mining(t *testing.T) {
 	headerMining := &types.Header{
 		ParentHash: header2100.ParentHash,
 		Number:     header2100.Number,
-		GasLimit:   params.V2TestsGasLimit,
+		GasLimit:   testGasLimit,
 		Time:       header2100.Time,
 		Coinbase:   acc1Addr,
 	}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -18,11 +18,6 @@ package params
 
 import "math/big"
 
-var (
-	TargetGasLimit  uint64 = XDCGenesisGasLimit // The artificial target
-	V2TestsGasLimit uint64 = 1200000000         // The gas limit used in the v2 consensus tests
-)
-
 const (
 	GasLimitBoundDivisor uint64 = 1024               // The bound divisor of the gas limit, used in update calculations.
 	MinGasLimit          uint64 = 5000               // Minimum the gas limit may ever be.
@@ -97,16 +92,7 @@ const (
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529
 	RefundQuotient        uint64 = 2
 	RefundQuotientEIP3529 uint64 = 5
-)
 
-var (
-	DifficultyBoundDivisor = big.NewInt(2048)   // The bound divisor of the difficulty, used in the update calculations.
-	GenesisDifficulty      = big.NewInt(131072) // Difficulty of the Genesis block.
-	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
-	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
-)
-
-const (
 	NetSstoreNoopGas  uint64 = 200   // Once per SSTORE operation if the value doesn't change.
 	NetSstoreInitGas  uint64 = 20000 // Once per SSTORE operation from clean zero.
 	NetSstoreCleanGas uint64 = 5000  // Once per SSTORE operation from clean non-zero.
@@ -174,4 +160,13 @@ const (
 	Bn256PairingBaseGasIstanbul      uint64 = 45000  // Base price for an elliptic curve pairing check
 	Bn256PairingPerPointGasByzantium uint64 = 80000  // Byzantium per-point price for an elliptic curve pairing check
 	Bn256PairingPerPointGasIstanbul  uint64 = 34000  // Per-point price for an elliptic curve pairing check
+)
+
+var (
+	DifficultyBoundDivisor = big.NewInt(2048)   // The bound divisor of the difficulty, used in the update calculations.
+	GenesisDifficulty      = big.NewInt(131072) // Difficulty of the Genesis block.
+	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
+	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
+
+	TargetGasLimit uint64 = XDCGenesisGasLimit // The artificial target
 )


### PR DESCRIPTION
# Proposed changes

- V2TestsGasLimit should be changed to const
- V2TestsGasLimit is only used by engine_v2_tests package

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
