### PR TITLE
feat(rlp): add RawList for working with un-decoded lists #33755

### DIFF
--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -102,6 +102,29 @@ func EncodeToReader(val interface{}) (size int, r io.Reader, err error) {
 	return buf.size(), &encReader{buf: buf}, nil
 }
 
+// EncodeToRawList encodes val as an RLP list and returns it as a RawList.
+func EncodeToRawList[T any](val []T) (RawList[T], error) {
+	if len(val) == 0 {
+		return RawList[T]{}, nil
+	}
+
+	// Encode the value to an internal buffer.
+	buf := getEncBuffer()
+	defer encBufferPool.Put(buf)
+	if err := buf.encode(val); err != nil {
+		return RawList[T]{}, err
+	}
+
+	// Create the RawList. RawList assumes the initial list header is padded
+	// 9 bytes, so we have to determine the offset where the value should be
+	// placed.
+	contentSize := buf.lheads[0].size
+	bytes := make([]byte, contentSize+9)
+	offset := 9 - headsize(uint64(contentSize))
+	buf.copyTo(bytes[offset:])
+	return RawList[T]{enc: bytes}, nil
+}
+
 type listhead struct {
 	offset int // index of this header in string data
 	size   int // total size of encoded data (including list headers)

--- a/rlp/iterator.go
+++ b/rlp/iterator.go
@@ -16,14 +16,16 @@
 
 package rlp
 
-type listIterator struct {
-	data []byte
-	next []byte
-	err  error
+// Iterator is an iterator over the elements of an encoded container.
+type Iterator struct {
+	data   []byte
+	next   []byte
+	offset int
+	err    error
 }
 
-// NewListIterator creates an iterator for the (list) represented by data
-func NewListIterator(data RawValue) (*listIterator, error) {
+// NewListIterator creates an iterator for the (list) represented by data.
+func NewListIterator(data RawValue) (*Iterator, error) {
 	k, t, c, err := readKind(data)
 	if err != nil {
 		return nil, err
@@ -31,16 +33,18 @@ func NewListIterator(data RawValue) (*listIterator, error) {
 	if k != List {
 		return nil, ErrExpectedList
 	}
-	it := &listIterator{
-		data: data[t : t+c],
-	}
+	it := &Iterator{data: data[t : t+c], offset: int(t)}
 	return it, nil
+}
+
+func newIterator(data []byte) *Iterator {
+	return &Iterator{data: data}
 }
 
 // Next forwards the iterator one step.
 // Returns true if there is a next item or an error occurred on this step (check Err()).
 // On parse error, the iterator is marked finished and subsequent calls return false.
-func (it *listIterator) Next() bool {
+func (it *Iterator) Next() bool {
 	if len(it.data) == 0 {
 		return false
 	}
@@ -52,17 +56,34 @@ func (it *listIterator) Next() bool {
 		it.data = nil
 		return true
 	}
-	it.next = it.data[:t+c]
-	it.data = it.data[t+c:]
+	length := t + c
+	it.next = it.data[:length]
+	it.data = it.data[length:]
+	it.offset += int(length)
 	it.err = nil
 	return true
 }
 
-// Value returns the current value
-func (it *listIterator) Value() []byte {
+// Count returns the remaining number of items.
+// Note this is O(n) and the result may be incorrect if the list data is invalid.
+// The returned count is always an upper bound on the remaining items
+// that will be visited by the iterator.
+func (it *Iterator) Count() int {
+	count, _ := CountValues(it.data)
+	return count
+}
+
+// Value returns the current value.
+func (it *Iterator) Value() []byte {
 	return it.next
 }
 
-func (it *listIterator) Err() error {
+// Offset returns the offset of the current value into the list data.
+func (it *Iterator) Offset() int {
+	return it.offset - len(it.next)
+}
+
+// Err returns the error that caused Next to return false, if any.
+func (it *Iterator) Err() error {
 	return it.err
 }

--- a/rlp/iterator_test.go
+++ b/rlp/iterator_test.go
@@ -38,10 +38,18 @@ func TestIterator(t *testing.T) {
 		t.Fatal("expected two elems, got zero")
 	}
 	txs := it.Value()
+	if offset := it.Offset(); offset != 3 {
+		t.Fatal("wrong offset", offset, "want 3")
+	}
+
 	// Check that uncles exist
 	if !it.Next() {
 		t.Fatal("expected two elems, got one")
 	}
+	if offset := it.Offset(); offset != 219 {
+		t.Fatal("wrong offset", offset, "want 219")
+	}
+
 	txit, err := NewListIterator(txs)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
# Proposed changes

This adds a new type wrapper that decodes as a list, but does not actually decode the contents of the list. The type parameter exists as a marker, and enables decoding the elements lazily. RawList can also be used for building a list incrementally.

Ref: #33755

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
