### PR TITLE
fix(metrics): add missing GaugeInfo case in GetAll() #33748

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -143,6 +143,8 @@ func (r *StandardRegistry) GetAll() map[string]map[string]interface{} {
 			values["value"] = metric.Snapshot().Value()
 		case *GaugeFloat64:
 			values["value"] = metric.Snapshot().Value()
+		case *GaugeInfo:
+			values["value"] = metric.Snapshot().Value()
 		case *Healthcheck:
 			values["error"] = nil
 			metric.Check()


### PR DESCRIPTION
# Proposed changes

GetAll did not return GaugeInfo metrics, which affects "chain/info" and "geth/info".

Ref: #33748

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
