### PR TITLE
feat(accounts): add support for Ledger Nano Gen5 #33297

### DIFF
--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -43,6 +43,14 @@ const refreshCycle = time.Second
 // trashing.
 const refreshThrottling = 500 * time.Millisecond
 
+const (
+	// deviceUsagePage identifies Ledger devices by HID usage page (0xffa0) on Windows and macOS.
+	// See: https://github.com/LedgerHQ/ledger-live/blob/05a2980e838955a11a1418da638ef8ac3df4fb74/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+	deviceUsagePage = 0xffa0
+	// deviceInterface identifies Ledger devices by USB interface number (0) on Linux.
+	deviceInterface = 0
+)
+
 // Hub is a accounts.Backend that can find and handle generic USB hardware wallets.
 type Hub struct {
 	scheme     string                  // Protocol scheme prefixing account and wallet URLs.
@@ -82,6 +90,7 @@ func NewLedgerHub() (*Hub, error) {
 		0x0005, /* Ledger Nano S Plus */
 		0x0006, /* Ledger Nano FTS */
 		0x0007, /* Ledger Flex */
+		0x0008, /* Ledger Nano Gen5 */
 
 		0x0000, /* WebUSB Ledger Blue */
 		0x1000, /* WebUSB Ledger Nano S */
@@ -89,7 +98,8 @@ func NewLedgerHub() (*Hub, error) {
 		0x5000, /* WebUSB Ledger Nano S Plus */
 		0x6000, /* WebUSB Ledger Nano FTS */
 		0x7000, /* WebUSB Ledger Flex */
-	}, 0xffa0, 0, newLedgerDriver)
+		0x8000, /* WebUSB Ledger Nano Gen5 */
+	}, deviceUsagePage, deviceInterface, newLedgerDriver)
 }
 
 // NewTrezorHubWithHID creates a new hardware wallet manager for Trezor devices.


### PR DESCRIPTION
# Proposed changes

adds support for the 0x0008 / 0x8000 product ID (Ledger Apex | Nano Gen5).

Ref: #33297

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
