### PR TITLE
fix(trie): fix embedded node size validation #33803

### DIFF
--- a/trie/node.go
+++ b/trie/node.go
@@ -215,8 +215,8 @@ func decodeRef(buf []byte) (node, []byte, error) {
 	case kind == rlp.List:
 		// 'embedded' Node reference. The encoding must be smaller
 		// than a hash in order to be valid.
-		if size := len(buf) - len(rest); size > hashLen {
-			err := fmt.Errorf("oversized embedded Node (size is %d bytes, want size < %d)", size, hashLen)
+		if size := len(buf) - len(rest); size >= hashLen {
+			err := fmt.Errorf("oversized embedded node (size is %d bytes, want size < %d)", size, hashLen)
 			return nil, buf, err
 		}
 		n, err := decodeNode(nil, buf)


### PR DESCRIPTION
# Proposed changes

The `decodeRef` function used `size > hashLen` to reject oversized embedded nodes, but this incorrectly allowed nodes of exactly 32 bytes through. The encoding side (hasher.go, stacktrie.go) consistently uses `len(enc) < 32` to decide whether to embed a node inline, meaning nodes of 32+ bytes are always hash-referenced. The error message itself already stated `want size < 32`, confirming the intended threshold. Changed `size > hashLen` to `size >= hashLen` in `decodeRef` to align the decoding validation with the encoding logic, the Yellow Paper spec, and the surrounding comments.

Ref: #33803

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
