### PR TITLE
fix(core): hex encode validators/validator/penalties in Header JSON

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -95,6 +95,9 @@ type headerMarshaling struct {
 	GasUsed    hexutil.Uint64
 	Time       hexutil.Uint64
 	Extra      hexutil.Bytes
+	Validators hexutil.Bytes
+	Validator  hexutil.Bytes
+	Penalties  hexutil.Bytes
 	BaseFee    *hexutil.Big
 	Hash       common.Hash `json:"hash"` // adds call to Hash() in MarshalJSON
 }

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -31,9 +31,9 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		Extra       hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   common.Hash    `json:"mixHash"          gencodec:"required"`
 		Nonce       BlockNonce     `json:"nonce"            gencodec:"required"`
-		Validators  []byte         `json:"validators"       gencodec:"required"`
-		Validator   []byte         `json:"validator"        gencodec:"required"`
-		Penalties   []byte         `json:"penalties"        gencodec:"required"`
+		Validators  hexutil.Bytes  `json:"validators"       gencodec:"required"`
+		Validator   hexutil.Bytes  `json:"validator"        gencodec:"required"`
+		Penalties   hexutil.Bytes  `json:"penalties"        gencodec:"required"`
 		BaseFee     *hexutil.Big   `json:"baseFeePerGas" rlp:"optional"`
 		Hash        common.Hash    `json:"hash"`
 	}
@@ -79,9 +79,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		Extra       *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   *common.Hash    `json:"mixHash"          gencodec:"required"`
 		Nonce       *BlockNonce     `json:"nonce"            gencodec:"required"`
-		Validators  []byte          `json:"validators"       gencodec:"required"`
-		Validator   []byte          `json:"validator"        gencodec:"required"`
-		Penalties   []byte          `json:"penalties"        gencodec:"required"`
+		Validators  *hexutil.Bytes  `json:"validators"       gencodec:"required"`
+		Validator   *hexutil.Bytes  `json:"validator"        gencodec:"required"`
+		Penalties   *hexutil.Bytes  `json:"penalties"        gencodec:"required"`
 		BaseFee     *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
 	}
 	var dec Header
@@ -151,15 +151,15 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	if dec.Validators == nil {
 		return errors.New("missing required field 'validators' for Header")
 	}
-	h.Validators = dec.Validators
+	h.Validators = *dec.Validators
 	if dec.Validator == nil {
 		return errors.New("missing required field 'validator' for Header")
 	}
-	h.Validator = dec.Validator
+	h.Validator = *dec.Validator
 	if dec.Penalties == nil {
 		return errors.New("missing required field 'penalties' for Header")
 	}
-	h.Penalties = dec.Penalties
+	h.Penalties = *dec.Penalties
 	if dec.BaseFee != nil {
 		h.BaseFee = (*big.Int)(dec.BaseFee)
 	}


### PR DESCRIPTION
# Proposed changes

Ensure JSON marshal/unmarshal uses hex for validators, validator, and penalties so Header encoding is consistent with RPC output.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
