### PR TITLE
fix(common/countdown): stabilize reset timing assertions

### DIFF
--- a/common/countdown/countdown_test.go
+++ b/common/countdown/countdown_test.go
@@ -60,13 +60,15 @@ firstReset:
 		}
 	}
 
-	// Now the countdown is paused after calling the callback function, let's reset it again
+	// The countdown keeps running after calling the callback; it is still initialised.
+	// Reset it again to verify that an explicit Reset extends the timeout by a full interval.
 	assert.True(t, countdown.isInitilised())
+	countdown.Reset(fakeI, 0, 0)
 	expectedTimeAfterReset := time.Now().Add(5000 * time.Millisecond)
 	<-called
 	// Always initilised
 	assert.True(t, countdown.isInitilised())
-	if time.Now().After(expectedTimeAfterReset) {
+	if !time.Now().Before(expectedTimeAfterReset) {
 		t.Log("Correctly reset the countdown second time")
 	} else {
 		t.Fatalf("Countdown did not reset correctly second time")
@@ -109,13 +111,15 @@ firstReset:
 		}
 	}
 
-	// Now the countdown is paused after calling the callback function, let's reset it again
+	// The countdown continues running (auto-resets) after calling the callback
+	// function; reset it again to verify it can still be reset after an error
 	assert.True(t, countdown.isInitilised())
+	countdown.Reset(fakeI, 0, 0)
 	expectedTimeAfterReset := time.Now().Add(5000 * time.Millisecond)
 	<-called
 	// Always initilised
 	assert.True(t, countdown.isInitilised())
-	if time.Now().After(expectedTimeAfterReset) {
+	if !time.Now().Before(expectedTimeAfterReset) {
 		t.Log("Correctly reset the countdown second time")
 	} else {
 		t.Fatalf("Countdown did not reset correctly second time")


### PR DESCRIPTION
# Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Fix flaky countdown reset tests by performing an explicit second Reset before validating the second timeout window, and using a boundary-safe time check.

Observed failure:

--- FAIL: TestCountdownShouldReset (14.00s)
    countdown_test.go:53: Correctly reset the countdown once
    countdown_test.go:72: Countdown did not reset correctly second time

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
