### PR TITLE
refactor(txpool): remove wrapper type #27841

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1147,11 +1147,11 @@ func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Addr
 		if lazyTx == nil {
 			break
 		}
-		warped := lazyTx.Resolve()
-		if warped == nil {
+		resolvedTx := lazyTx.Resolve()
+		if resolvedTx == nil {
 			break
 		}
-		tx := warped
+		tx := resolvedTx
 		to := tx.To()
 		if w.header.Number.Uint64() >= common.DenylistHFNumber {
 			from := tx.From()


### PR DESCRIPTION
# Proposed changes

Partial backport of PR #27841 which only limited to txpool wrapper removal.
- Migrate txpool interfaces/call sites from `*txpool.Transaction` to `*types.Transaction`
- Update eth/miner/contracts paths and related tests accordingly
- No intended behavior change

Blob sidecar validation/handling changes from upstream are not included here.

Ref: #27841

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [X] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
