### PR TITLE
test(build,Makefile): switch quick-test from --quick to -short

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ all:
 test: all
 	go run build/ci.go test -failfast
 
-#? quick-test: Run the tests except time-consuming packages.
+#? quick-test: Run tests in short mode (testing.Short()), fail fast.
 quick-test: all
-	go run build/ci.go test --quick -failfast
+	go run build/ci.go test -short -failfast
 
 #? lint: Run certain pre-selected linters.
 lint: ## Run linters.

--- a/build/ci.go
+++ b/build/ci.go
@@ -212,7 +212,6 @@ func doTest(cmdline []string) {
 		race     = flag.Bool("race", false, "Execute the race detector")
 		short    = flag.Bool("short", false, "Pass the 'short'-flag to go test")
 		threads  = flag.Int("p", 1, "Number of CPU threads to use for testing")
-		quick    = flag.Bool("quick", false, "Whether to skip long time test")
 		failfast = flag.Bool("failfast", false, "Do not start new tests after the first test failure")
 	)
 	flag.CommandLine.Parse(cmdline)
@@ -255,40 +254,18 @@ func doTest(cmdline []string) {
 
 	packages := flag.CommandLine.Args()
 	if len(packages) > 0 {
-		if *quick {
-			packages = filterPackages(packages)
-		}
 		gotest.Args = append(gotest.Args, packages...)
 		build.MustRun(gotest)
 		return
 	}
 
 	// No packages specified, run all tests for all modules.
-	if *quick {
-		packages = filterPackages(build.FindAllPackages(&tc))
-	} else {
-		packages = []string{"./..."}
-	}
-	gotest.Args = append(gotest.Args, packages...)
+	gotest.Args = append(gotest.Args, "./...")
 	for _, mod := range goModules {
 		test := *gotest
 		test.Dir = mod
 		build.MustRun(&test)
 	}
-}
-
-// filterPackages removes time-consuming packages.
-func filterPackages(packages []string) []string {
-	var filtered []string
-
-	for _, pkg := range packages {
-		if strings.Contains(pkg, "/consensus/tests/engine_v2_tests") {
-			continue
-		}
-		filtered = append(filtered, pkg)
-	}
-
-	return filtered
 }
 
 // doTidy runs go mod tidy check.


### PR DESCRIPTION
# Proposed changes

Replace the quick-test target to run `go run build/ci.go test -short -failfast`.

Remove the `--quick` flag and package-filter path from `build/ci.go`, so test selection relies on Go's built-in short mode instead of custom package exclusion.

This keeps quick-test behavior aligned with tests guarded by `testing.Short()` and avoids maintaining bespoke skip logic in CI tooling.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [X] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
