### PR TITLE
refactor(miner): polish miner configuration #19480

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -39,7 +39,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/metrics"
 	"github.com/XinFinOrg/XDPoSChain/node"
-	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/urfave/cli/v2"
 
 	// Force-load the tracer engines to trigger registration
@@ -238,7 +237,6 @@ func init() {
 		// Start system runtime metrics collection
 		go metrics.CollectProcessMetrics(3 * time.Second)
 
-		params.TargetGasLimit = ctx.Uint64(utils.MinerGasLimitFlag.Name)
 		return nil
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -57,6 +57,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/metrics"
 	"github.com/XinFinOrg/XDPoSChain/metrics/exp"
 	"github.com/XinFinOrg/XDPoSChain/metrics/influxdb"
+	"github.com/XinFinOrg/XDPoSChain/miner"
 	"github.com/XinFinOrg/XDPoSChain/node"
 	"github.com/XinFinOrg/XDPoSChain/p2p"
 	"github.com/XinFinOrg/XDPoSChain/p2p/discover"
@@ -330,15 +331,15 @@ var (
 	MinerGasLimitFlag = &cli.Uint64Flag{
 		Name:     "miner-gaslimit",
 		Aliases:  []string{"targetgaslimit"},
-		Usage:    "Target gas limit sets the artificial target gas floor for the blocks to mine",
-		Value:    50000000,
+		Usage:    "Target gas ceiling for mined blocks",
+		Value:    ethconfig.Defaults.Miner.GasCeil,
 		Category: flags.MinerCategory,
 	}
 	MinerGasPriceFlag = &flags.BigFlag{
 		Name:     "miner-gasprice",
 		Aliases:  []string{"gasprice"},
-		Usage:    "Minimal gas price to accept for mining a transactions",
-		Value:    big.NewInt(1),
+		Usage:    "Minimum gas price for mining a transaction",
+		Value:    new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice),
 		Category: flags.MinerCategory,
 	}
 	MinerEtherbaseFlag = &cli.StringFlag{
@@ -1255,11 +1256,11 @@ func setEtherbase(ctx *cli.Context, ks *keystore.KeyStore, cfg *ethconfig.Config
 		if err != nil {
 			Fatalf("Option %q: %v", MinerEtherbaseFlag.Name, err)
 		}
-		cfg.Etherbase = account.Address
+		cfg.Miner.Etherbase = account.Address
 	} else {
 		if !ctx.IsSet(UnlockedAccountFlag.Name) {
-			cfg.Etherbase = common.HexToAddress(ctx.String(MinerEtherbaseFlag.Name))
-			log.Info("Set etherbase", "address", cfg.Etherbase.Hex())
+			cfg.Miner.Etherbase = common.HexToAddress(ctx.String(MinerEtherbaseFlag.Name))
+			log.Info("Set etherbase", "address", cfg.Miner.Etherbase.Hex())
 		}
 	}
 }
@@ -1454,6 +1455,22 @@ func setTxPool(ctx *cli.Context, cfg *legacypool.Config) {
 	}
 }
 
+func setMiner(ctx *cli.Context, cfg *miner.Config) {
+	if ctx.IsSet(MinerExtraDataFlag.Name) {
+		cfg.ExtraData = []byte(ctx.String(MinerExtraDataFlag.Name))
+	}
+	if ctx.IsSet(MinerGasLimitFlag.Name) {
+		cfg.GasCeil = ctx.Uint64(MinerGasLimitFlag.Name)
+	}
+	if ctx.IsSet(MinerGasPriceFlag.Name) {
+		cfg.GasPrice = flags.GlobalBig(ctx, MinerGasPriceFlag.Name)
+	}
+	if cfg.GasCeil == 0 {
+		log.Warn("Sanitizing invalid miner gas limit", "provided", cfg.GasCeil, "updated", ethconfig.Defaults.Miner.GasCeil)
+		cfg.GasCeil = ethconfig.Defaults.Miner.GasCeil
+	}
+}
+
 func SetXDCXConfig(ctx *cli.Context, cfg *XDCx.Config, XDCDataDir string) {
 	if ctx.IsSet(XDCXDataDirFlag.Name) {
 		log.Warn("The flag XDCx-datadir or XDCx.datadir is deprecated, please remove this flag")
@@ -1476,6 +1493,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	setEtherbase(ctx, ks, cfg)
 	setGPO(ctx, &cfg.GPO)
 	setTxPool(ctx, &cfg.TxPool)
+	setMiner(ctx, &cfg.Miner)
 	setLes(ctx, cfg)
 
 	// Cap the cache allowance and tune the garbage collector
@@ -1527,9 +1545,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheGCFlag.Name) {
 		cfg.TrieDirtyCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheGCFlag.Name) / 100
 	}
-	if ctx.IsSet(MinerThreadsFlag.Name) {
-		cfg.MinerThreads = ctx.Int(MinerThreadsFlag.Name)
-	}
 	if ctx.IsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = ctx.Uint64(RPCGlobalGasCapFlag.Name)
 	}
@@ -1542,10 +1557,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(RPCGlobalRangeLimitFlag.Name) {
 		cfg.RangeLimit = ctx.Uint64(RPCGlobalRangeLimitFlag.Name)
 	}
-	if ctx.IsSet(MinerExtraDataFlag.Name) {
-		cfg.ExtraData = []byte(ctx.String(MinerExtraDataFlag.Name))
-	}
-	cfg.GasPrice = flags.GlobalBig(ctx, MinerGasPriceFlag.Name)
 	if ctx.IsSet(CacheLogSizeFlag.Name) {
 		cfg.FilterLogCacheSize = ctx.Int(CacheLogSizeFlag.Name)
 	}
@@ -1618,6 +1629,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Info("Using developer account", "address", developer.Address)
 
 		cfg.Genesis = core.DeveloperGenesisBlock(uint64(ctx.Int(DeveloperPeriodFlag.Name)), developer.Address)
+		if !ctx.IsSet(MinerGasPriceFlag.Name) {
+			cfg.Miner.GasPrice = big.NewInt(1)
+		}
 	}
 
 	// VM tracing config.

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/eth"
 	"github.com/XinFinOrg/XDPoSChain/eth/ethconfig"
 	"github.com/XinFinOrg/XDPoSChain/internal/jsre"
+	"github.com/XinFinOrg/XDPoSChain/miner"
 	"github.com/XinFinOrg/XDPoSChain/node"
 )
 
@@ -97,8 +98,10 @@ func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
 		t.Fatalf("failed to create node: %v", err)
 	}
 	ethConf := &ethconfig.Config{
-		Genesis:   core.DeveloperGenesisBlock(15, common.Address{}),
-		Etherbase: common.HexToAddress(testAddress),
+		Genesis: core.DeveloperGenesisBlock(15, common.Address{}),
+		Miner: miner.Config{
+			Etherbase: common.HexToAddress(testAddress),
+		},
 	}
 	if confOverride != nil {
 		confOverride(ethConf)

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -110,7 +110,7 @@ func init() {
 func genTxRing(naccounts int) func(int, *BlockGen) {
 	from := 0
 	return func(i int, gen *BlockGen) {
-		gas := CalcGasLimit(gen.PrevBlock(i-1).GasLimit(), params.TargetGasLimit)
+		gas := CalcGasLimit(gen.PrevBlock(i-1).GasLimit(), params.XDCGenesisGasLimit)
 		for {
 			gas -= params.TxGas
 			if gas < params.TxGas {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -304,7 +304,7 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 			Difficulty: parent.Difficulty(),
 			UncleHash:  parent.UncleHash(),
 		}),
-		GasLimit: CalcGasLimit(parent.GasLimit(), params.TargetGasLimit),
+		GasLimit: CalcGasLimit(parent.GasLimit(), params.XDCGenesisGasLimit),
 		Number:   new(big.Int).Add(parent.Number(), common.Big1),
 		Time:     time,
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -115,6 +115,14 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	if !config.SyncMode.IsValid() {
 		return nil, fmt.Errorf("invalid sync mode %d", config.SyncMode)
 	}
+	if config.Miner.GasCeil == 0 {
+		log.Warn("Sanitizing invalid miner gas limit", "provided", config.Miner.GasCeil, "updated", ethconfig.Defaults.Miner.GasCeil)
+		config.Miner.GasCeil = ethconfig.Defaults.Miner.GasCeil
+	}
+	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(common.Big0) < 0 {
+		log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
+		config.Miner.GasPrice = new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice)
+	}
 
 	chainDb, err := stack.OpenDatabase("chaindata", config.DatabaseCache, config.DatabaseHandles, "eth/db/chaindata/", false)
 	if err != nil {
@@ -144,8 +152,8 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 		engine:         CreateConsensusEngine(stack, chainConfig, chainDb),
 		shutdownChan:   make(chan bool),
 		networkId:      networkID,
-		gasPrice:       config.GasPrice,
-		etherbase:      config.Etherbase,
+		gasPrice:       config.Miner.GasPrice,
+		etherbase:      config.Miner.Etherbase,
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
 		bloomIndexer:   NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms),
 		p2pServer:      stack.Server(),
@@ -273,8 +281,8 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	if eth.protocolManager, err = NewProtocolManagerEx(eth.blockchain.Config(), config.SyncMode, networkID, eth.eventMux, eth.txPool, eth.orderPool, eth.lendingPool, eth.engine, eth.blockchain, chainDb); err != nil {
 		return nil, err
 	}
-	eth.miner = miner.New(eth, eth.blockchain.Config(), eth.EventMux(), eth.engine, stack.Config().AnnounceTxs)
-	eth.miner.SetExtra(makeExtraData(config.ExtraData))
+	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, stack.Config().AnnounceTxs)
+	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
 	var xdPoS *XDPoS.XDPoS = nil
 	if eth.chainConfig.XDPoS != nil {
@@ -290,7 +298,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}
-	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, config.GPO, config.GasPrice)
+	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, config.GPO, config.Miner.GasPrice)
 
 	// Set global ipc endpoint.
 	eth.blockchain.IPCEndpoint = stack.IPCEndpoint()

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -18,16 +18,13 @@
 package ethconfig
 
 import (
-	"math/big"
 	"time"
 
-	"github.com/XinFinOrg/XDPoSChain/common"
-	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/txpool/legacypool"
 	"github.com/XinFinOrg/XDPoSChain/eth/downloader"
 	"github.com/XinFinOrg/XDPoSChain/eth/gasprice"
-	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/miner"
 )
 
 // FullNodeGPO contains default gasprice oracle settings for full node.
@@ -50,8 +47,8 @@ var Defaults = Config{
 	TrieDirtyCache:     256,
 	TrieTimeout:        5 * time.Minute,
 	FilterLogCacheSize: 32,
+	Miner:              miner.DefaultConfig,
 	LogQueryLimit:      1000,
-	GasPrice:           big.NewInt(0.25 * params.Shannon),
 	TxPool:             legacypool.DefaultConfig,
 	RPCGasCap:          50000000,
 	RPCEVMTimeout:      5 * time.Second,
@@ -60,7 +57,7 @@ var Defaults = Config{
 	RangeLimit:         5000,
 }
 
-//go:generate go run github.com/fjl/gencodec -type Config -field-override configMarshaling -formats toml -out gen_config.go
+//go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go
 
 // Config contains configuration options for of the ETH and LES protocols.
 type Config struct {
@@ -93,15 +90,12 @@ type Config struct {
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int
 
+	// Mining options
+	Miner miner.Config
+
 	// This is the maximum number of addresses or topics allowed in filter criteria
 	// for eth_getLogs.
 	LogQueryLimit int
-
-	// Mining-related options
-	Etherbase    common.Address `toml:",omitempty"`
-	MinerThreads int            `toml:",omitempty"`
-	ExtraData    []byte         `toml:",omitempty"`
-	GasPrice     *big.Int
 
 	// Transaction pool options
 	TxPool legacypool.Config
@@ -128,8 +122,4 @@ type Config struct {
 
 	// RangeLimit restricts the maximum range (end - start) for range queries.
 	RangeLimit uint64 `toml:",omitempty"`
-}
-
-type configMarshaling struct {
-	ExtraData hexutil.Bytes
 }

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -3,18 +3,14 @@
 package ethconfig
 
 import (
-	"math/big"
 	"time"
 
-	"github.com/XinFinOrg/XDPoSChain/common"
-	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/txpool/legacypool"
 	"github.com/XinFinOrg/XDPoSChain/eth/downloader"
 	"github.com/XinFinOrg/XDPoSChain/eth/gasprice"
+	"github.com/XinFinOrg/XDPoSChain/miner"
 )
-
-var _ = (*configMarshaling)(nil)
 
 // MarshalTOML marshals as TOML.
 func (c Config) MarshalTOML() (interface{}, error) {
@@ -35,11 +31,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TrieTimeout             time.Duration
 		Preimages               bool
 		FilterLogCacheSize      int
+		Miner                   miner.Config
 		LogQueryLimit           int
-		Etherbase               common.Address `toml:",omitempty"`
-		MinerThreads            int            `toml:",omitempty"`
-		ExtraData               hexutil.Bytes  `toml:",omitempty"`
-		GasPrice                *big.Int
 		TxPool                  legacypool.Config
 		GPO                     gasprice.Config
 		EnablePreimageRecording bool
@@ -67,11 +60,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TrieTimeout = c.TrieTimeout
 	enc.Preimages = c.Preimages
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
+	enc.Miner = c.Miner
 	enc.LogQueryLimit = c.LogQueryLimit
-	enc.Etherbase = c.Etherbase
-	enc.MinerThreads = c.MinerThreads
-	enc.ExtraData = c.ExtraData
-	enc.GasPrice = c.GasPrice
 	enc.TxPool = c.TxPool
 	enc.GPO = c.GPO
 	enc.EnablePreimageRecording = c.EnablePreimageRecording
@@ -103,11 +93,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TrieTimeout             *time.Duration
 		Preimages               *bool
 		FilterLogCacheSize      *int
+		Miner                   *miner.Config
 		LogQueryLimit           *int
-		Etherbase               *common.Address `toml:",omitempty"`
-		MinerThreads            *int            `toml:",omitempty"`
-		ExtraData               *hexutil.Bytes  `toml:",omitempty"`
-		GasPrice                *big.Int
 		TxPool                  *legacypool.Config
 		GPO                     *gasprice.Config
 		EnablePreimageRecording *bool
@@ -170,20 +157,11 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize
 	}
+	if dec.Miner != nil {
+		c.Miner = *dec.Miner
+	}
 	if dec.LogQueryLimit != nil {
 		c.LogQueryLimit = *dec.LogQueryLimit
-	}
-	if dec.Etherbase != nil {
-		c.Etherbase = *dec.Etherbase
-	}
-	if dec.MinerThreads != nil {
-		c.MinerThreads = *dec.MinerThreads
-	}
-	if dec.ExtraData != nil {
-		c.ExtraData = *dec.ExtraData
-	}
-	if dec.GasPrice != nil {
-		c.GasPrice = dec.GasPrice
 	}
 	if dec.TxPool != nil {
 		c.TxPool = *dec.TxPool

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -19,12 +19,14 @@ package miner
 
 import (
 	"fmt"
+	"math/big"
 	"sync/atomic"
 
 	"github.com/XinFinOrg/XDPoSChain/XDCx"
 	"github.com/XinFinOrg/XDPoSChain/XDCxlending"
 	"github.com/XinFinOrg/XDPoSChain/accounts"
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
 	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
@@ -50,6 +52,20 @@ type Backend interface {
 	GetXDCXLending() *XDCxlending.Lending
 }
 
+// Config is the configuration parameters of mining.
+type Config struct {
+	Etherbase common.Address `toml:",omitempty"` // Public address for block mining rewards
+	ExtraData hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
+	GasCeil   uint64         // Target gas ceiling for mined blocks.
+	GasPrice  *big.Int       // Minimum gas price for mining a transaction
+}
+
+// DefaultConfig contains default settings for miner.
+var DefaultConfig = Config{
+	GasCeil:  params.XDCGenesisGasLimit,
+	GasPrice: big.NewInt(1),
+}
+
 // Miner creates blocks and searches for proof-of-work values.
 type Miner struct {
 	mux *event.TypeMux
@@ -65,12 +81,12 @@ type Miner struct {
 	shouldStart int32 // should start indicates whether we should start after sync
 }
 
-func New(eth Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, announceTxs bool) *Miner {
+func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, announceTxs bool) *Miner {
 	miner := &Miner{
 		eth:      eth,
 		mux:      mux,
 		engine:   engine,
-		worker:   newWorker(config, engine, common.Address{}, eth, mux, announceTxs),
+		worker:   newWorker(config, chainConfig, engine, eth, mux, announceTxs),
 		canStart: 1,
 	}
 	miner.Register(NewCpuAgent(eth.BlockChain(), engine))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -113,8 +113,9 @@ type Result struct {
 
 // worker is the main object which takes care of applying messages to the new state
 type worker struct {
-	config *params.ChainConfig
-	engine consensus.Engine
+	config      *Config
+	chainConfig *params.ChainConfig
+	engine      consensus.Engine
 
 	mu sync.Mutex
 
@@ -164,12 +165,15 @@ type worker struct {
 	lastParentBlockCommit string
 }
 
-func newWorker(config *params.ChainConfig, engine consensus.Engine, coinbase common.Address, eth Backend, mux *event.TypeMux, announceTxs bool) *worker {
+func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, announceTxs bool) *worker {
 	worker := &worker{
 		config:         config,
+		chainConfig:    chainConfig,
 		engine:         engine,
 		eth:            eth,
 		mux:            mux,
+		coinbase:       config.Etherbase,
+		extra:          config.ExtraData,
 		txsCh:          make(chan core.NewTxsEvent, txChanSize),
 		chainHeadCh:    make(chan core.ChainHeadEvent, chainHeadChanSize),
 		chainSideCh:    make(chan core.ChainSideEvent, chainSideChanSize),
@@ -179,7 +183,6 @@ func newWorker(config *params.ChainConfig, engine consensus.Engine, coinbase com
 		chain:          eth.BlockChain(),
 		proc:           eth.BlockChain().Validator(),
 		possibleUncles: make(map[common.Hash]*types.Block),
-		coinbase:       coinbase,
 		agents:         make(map[Agent]struct{}),
 		unconfirmed:    newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
 		announceTxs:    announceTxs,
@@ -254,7 +257,7 @@ func (w *worker) start() {
 	if engine, ok := w.engine.(*XDPoS.XDPoS); ok {
 		xdposEngine = engine
 	}
-	if w.config != nil && w.config.XDPoS != nil && xdposEngine == nil {
+	if w.chainConfig != nil && w.chainConfig.XDPoS != nil && xdposEngine == nil {
 		log.Warn("XDPoS config enabled but consensus engine is not XDPoS")
 	}
 }
@@ -385,7 +388,7 @@ func (w *worker) update() {
 				txset, specialTxs := newTransactionsByPriceAndNonce(w.current.signer, txs, feeCapacity, w.current.header.BaseFee)
 
 				tcount := w.current.tcount
-				w.current.commitTransactions(w.mux, feeCapacity, txset, specialTxs, w.chain, w.coinbase, &w.pendingLogsFeed)
+				w.current.commitTransactions(w.mux, feeCapacity, txset, specialTxs, w.chain, &w.pendingLogsFeed)
 
 				// Only update the snapshot if any new transactions were added
 				// to the pending block
@@ -395,7 +398,7 @@ func (w *worker) update() {
 				w.currentMu.Unlock()
 			} else {
 				// If we're mining, but nothing is being processed, wake on new transactions
-				if w.config.XDPoS != nil && w.config.XDPoS.Period == 0 {
+				if w.chainConfig.XDPoS != nil && w.chainConfig.XDPoS.Period == 0 {
 					w.commitNewWork()
 				}
 			}
@@ -515,7 +518,7 @@ func (w *worker) wait() {
 				w.commitNewWork()
 			}
 
-			if w.config.XDPoS != nil {
+			if w.chainConfig.XDPoS != nil {
 				c := w.engine.(*XDPoS.XDPoS)
 				err = c.HandleProposedBlock(w.chain, block.Header())
 				if err != nil {
@@ -538,8 +541,8 @@ func (w *worker) wait() {
 					}
 				}
 				// Send tx sign to smart contract blockSigners.
-				if block.NumberU64()%common.MergeSignRange == 0 || !w.config.IsTIP2019(block.Number()) {
-					if err := contracts.CreateTransactionSign(w.config, w.eth.TxPool(), w.eth.AccountManager(), block, w.chainDb, w.coinbase); err != nil {
+				if block.NumberU64()%common.MergeSignRange == 0 || !w.chainConfig.IsTIP2019(block.Number()) {
+					if err := contracts.CreateTransactionSign(w.chainConfig, w.eth.TxPool(), w.eth.AccountManager(), block, w.chainDb, w.coinbase); err != nil {
 						log.Error("Fail to create tx sign for signer", "error", err)
 					}
 				}
@@ -625,7 +628,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 	author, _ := w.chain.Engine().Author(parent.Header())
 	var XDCxState *tradingstate.TradingStateDB
 	var lendingState *lendingstate.LendingStateDB
-	if w.config.XDPoS != nil {
+	if w.chainConfig.XDPoS != nil {
 		XDCX := w.eth.GetXDCX()
 		XDCxState, err = XDCX.GetTradingState(parent, author)
 		if err != nil {
@@ -641,8 +644,8 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 	}
 
 	work := &Work{
-		config:       w.config,
-		signer:       types.MakeSigner(w.config, header.Number),
+		config:       w.chainConfig,
+		signer:       types.MakeSigner(w.chainConfig, header.Number),
 		state:        state,
 		parentState:  state.Copy(),
 		tradingState: XDCxState,
@@ -650,7 +653,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 		ancestors:    mapset.NewSet[common.Hash](),
 		family:       mapset.NewSet[common.Hash](),
 		header:       header,
-		evm:          vm.NewEVM(core.NewEVMBlockContext(header, w.chain, &header.Coinbase), state, XDCxState, w.config, vm.Config{}),
+		evm:          vm.NewEVM(core.NewEVMBlockContext(header, w.chain, &header.Coinbase), state, XDCxState, w.chainConfig, vm.Config{}),
 		uncles:       make(map[common.Hash]*types.Header),
 		createdAt:    time.Now(),
 	}
@@ -695,7 +698,7 @@ func (w *worker) checkPreCommit() (*types.Block, bool) {
 	if parent == nil {
 		return nil, true
 	}
-	if w.config.XDPoS != nil && xdposEngine == nil {
+	if w.chainConfig.XDPoS != nil && xdposEngine == nil {
 		log.Debug("XDPoS config enabled but consensus engine is not XDPoS")
 		return parent, true
 	}
@@ -709,7 +712,7 @@ func (w *worker) checkPreCommit() (*types.Block, bool) {
 	// Only try to commit new work if we are mining
 	if atomic.LoadInt32(&w.mining) == 1 {
 		// check if we are right after parent's coinbase in the list
-		if w.config.XDPoS != nil && xdposEngine != nil {
+		if w.chainConfig.XDPoS != nil && xdposEngine != nil {
 			ok, err := xdposEngine.YourTurn(w.chain, parent.Header(), w.coinbase)
 			if err != nil {
 				log.Warn("Failed when trying to commit new work", "err", err)
@@ -761,13 +764,13 @@ func (w *worker) commitNewWork() {
 		Extra:      w.extra,
 		Time:       uint64(tstamp),
 	}
-	if w.config.IsDynamicGasLimitBlock(header.Number) {
-		header.GasLimit = core.CalcGasLimit(parent.GasLimit(), params.TargetGasLimit)
+	if w.chainConfig.IsDynamicGasLimitBlock(header.Number) {
+		header.GasLimit = core.CalcGasLimit(parent.GasLimit(), w.config.GasCeil)
 	} else {
-		header.GasLimit = params.TargetGasLimit
+		header.GasLimit = w.config.GasCeil
 	}
 	// Set baseFee if we are on an EIP-1559 chain
-	header.BaseFee = eip1559.CalcBaseFee(w.config, header)
+	header.BaseFee = eip1559.CalcBaseFee(w.chainConfig, header)
 
 	// Only set the coinbase if we are mining (avoid spurious block rewards)
 	if atomic.LoadInt32(&w.mining) == 1 {
@@ -783,12 +786,12 @@ func (w *worker) commitNewWork() {
 		return
 	}
 	// If we are care about TheDAO hard-fork check whether to override the extra-data or not
-	if daoBlock := w.config.DAOForkBlock; daoBlock != nil {
+	if daoBlock := w.chainConfig.DAOForkBlock; daoBlock != nil {
 		// Check whether the block is among the fork extra-override range
 		limit := new(big.Int).Add(daoBlock, params.DAOForkExtraRange)
 		if header.Number.Cmp(daoBlock) >= 0 && header.Number.Cmp(limit) < 0 {
 			// Depending whether we support or oppose the fork, override differently
-			if w.config.DAOForkSupport {
+			if w.chainConfig.DAOForkSupport {
 				header.Extra = common.CopyBytes(params.DAOForkBlockExtra)
 			} else if bytes.Equal(header.Extra, params.DAOForkBlockExtra) {
 				header.Extra = []byte{} // If miner opposes, don't let it use the reserved extra-data
@@ -803,13 +806,13 @@ func (w *worker) commitNewWork() {
 	}
 	// Create the current work task and check any fork transitions needed
 	work := w.current
-	if w.config.DAOForkSupport && w.config.DAOForkBlock != nil && w.config.DAOForkBlock.Cmp(header.Number) == 0 {
+	if w.chainConfig.DAOForkSupport && w.chainConfig.DAOForkBlock != nil && w.chainConfig.DAOForkBlock.Cmp(header.Number) == 0 {
 		misc.ApplyDAOHardFork(work.state)
 	}
 	if common.TIPSigning.Cmp(header.Number) == 0 {
 		work.state.DeleteAddress(common.BlockSignersBinary)
 	}
-	if w.config.IsPrague(header.Number) {
+	if w.chainConfig.IsPrague(header.Number) {
 		core.ProcessParentBlockHash(header.ParentHash, work.evm)
 	}
 	// won't grasp txs at checkpoint
@@ -823,7 +826,7 @@ func (w *worker) commitNewWork() {
 		liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades []*lendingstate.LendingTrade
 	)
 	feeCapacity := work.state.GetTRC21FeeCapacityFromStateWithCache(parent.Root())
-	if w.config.XDPoS != nil {
+	if w.chainConfig.XDPoS != nil {
 		isEpochSwitchBlock, _, err := w.engine.(*XDPoS.XDPoS).IsEpochSwitch(header)
 		if err != nil {
 			log.Error("[commitNewWork] fail to check if block is epoch switch block when fetching pending transactions", "BlockNum", header.Number, "Hash", header.Hash())
@@ -839,10 +842,10 @@ func (w *worker) commitNewWork() {
 			log.Warn("Can't find coinbase account wallet", "coinbase", w.coinbase, "err", err)
 			return
 		}
-		if w.config.XDPoS != nil && w.chain.Config().IsTIPXDCXMiner(header.Number) {
+		if w.chainConfig.XDPoS != nil && w.chain.Config().IsTIPXDCXMiner(header.Number) {
 			XDCX := w.eth.GetXDCX()
 			XDCXLending := w.eth.GetXDCXLending()
-			if XDCX != nil && header.Number.Uint64() > w.config.XDPoS.Epoch {
+			if XDCX != nil && header.Number.Uint64() > w.chainConfig.XDPoS.Epoch {
 				isEpochSwitchBlock, epochNumber, err := w.engine.(*XDPoS.XDPoS).IsEpochSwitch(header)
 				if err != nil {
 					log.Error("[commitNewWork] fail to check if block is epoch switch block when performing XDCX and XDCXLending operations", "BlockNum", header.Number, "Hash", header.Hash())
@@ -866,7 +869,7 @@ func (w *worker) commitNewWork() {
 					lendingOrderPending, _ := w.eth.LendingPool().Pending()
 					lendingInput, lendingMatchingResults = XDCXLending.ProcessOrderPending(header, w.coinbase, w.chain, lendingOrderPending, work.state, work.lendingState, work.tradingState)
 					log.Debug("lending transaction matches found", "lendingInput", len(lendingInput), "lendingMatchingResults", len(lendingMatchingResults))
-					if header.Number.Uint64()%w.config.XDPoS.Epoch == common.LiquidateLendingTradeBlock {
+					if header.Number.Uint64()%w.chainConfig.XDPoS.Epoch == common.LiquidateLendingTradeBlock {
 						updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, err = XDCXLending.ProcessLiquidationData(header, w.chain, work.state, work.tradingState, work.lendingState)
 						if err != nil {
 							log.Error("Fail when process lending liquidation data ", "error", err)
@@ -888,7 +891,7 @@ func (w *worker) commitNewWork() {
 					}
 					nonce := work.state.GetNonce(w.coinbase)
 					tx := types.NewTransaction(nonce, common.XDCXAddrBinary, big.NewInt(0), txMatchGasLimit, big.NewInt(0), txMatchBytes)
-					txM, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, tx, w.config.ChainID)
+					txM, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, tx, w.chainConfig.ChainID)
 					if err != nil {
 						log.Error("Fail to create tx matches", "error", err)
 						return
@@ -913,7 +916,7 @@ func (w *worker) commitNewWork() {
 					}
 					nonce := work.state.GetNonce(w.coinbase)
 					lendingTx := types.NewTransaction(nonce, common.XDCXLendingAddressBinary, big.NewInt(0), txMatchGasLimit, big.NewInt(0), lendingDataBytes)
-					signedLendingTx, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, lendingTx, w.config.ChainID)
+					signedLendingTx, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, lendingTx, w.chainConfig.ChainID)
 					if err != nil {
 						log.Error("Fail to create lending tx", "error", err)
 						return
@@ -932,7 +935,7 @@ func (w *worker) commitNewWork() {
 					}
 					nonce := work.state.GetNonce(w.coinbase)
 					finalizedTx := types.NewTransaction(nonce, common.XDCXLendingFinalizedTradeAddressBinary, big.NewInt(0), txMatchGasLimit, big.NewInt(0), finalizedTradeData)
-					signedFinalizedTx, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, finalizedTx, w.config.ChainID)
+					signedFinalizedTx, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, finalizedTx, w.chainConfig.ChainID)
 					if err != nil {
 						log.Error("Fail to create lending tx", "error", err)
 						return
@@ -946,7 +949,7 @@ func (w *worker) commitNewWork() {
 			LendingStateRoot := work.lendingState.IntermediateRoot()
 			txData := append(XDCxStateRoot.Bytes(), LendingStateRoot.Bytes()...)
 			tx := types.NewTransaction(work.state.GetNonce(w.coinbase), common.TradingStateAddrBinary, big.NewInt(0), txMatchGasLimit, big.NewInt(0), txData)
-			txStateRoot, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, tx, w.config.ChainID)
+			txStateRoot, err := wallet.SignTx(accounts.Account{Address: w.coinbase}, tx, w.chainConfig.ChainID)
 			if err != nil {
 				log.Error("Fail to create tx state root", "error", err)
 				return
@@ -954,7 +957,7 @@ func (w *worker) commitNewWork() {
 			specialTxs = append(specialTxs, txStateRoot)
 		}
 	}
-	work.commitTransactions(w.mux, feeCapacity, txs, specialTxs, w.chain, w.coinbase, &w.pendingLogsFeed)
+	work.commitTransactions(w.mux, feeCapacity, txs, specialTxs, w.chain, &w.pendingLogsFeed)
 	commitEnd := time.Now()
 
 	// compute uncles for the new block.
@@ -995,7 +998,7 @@ func (w *worker) commitNewWork() {
 	w.updateSnapshot()
 }
 
-func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Address]*big.Int, txs *transactionsByPriceAndNonce, specialTxs types.Transactions, bc *core.BlockChain, coinbase common.Address, pendingLogsFeed *event.Feed) {
+func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Address]*big.Int, txs *transactionsByPriceAndNonce, specialTxs types.Transactions, bc *core.BlockChain, pendingLogsFeed *event.Feed) {
 	gp := new(core.GasPool).AddGas(w.header.GasLimit)
 	balanceUpdated := map[common.Address]*big.Int{}
 	totalFeeUsed := big.NewInt(0)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -96,7 +96,7 @@ func TestWorkerCheckPreCommitXDPoSMismatch(t *testing.T) {
 	extraData = append(extraData, make([]byte, utils.ExtraSeal)...)
 	genesis := &core.Genesis{
 		Config:     config,
-		GasLimit:   params.TargetGasLimit,
+		GasLimit:   params.XDCGenesisGasLimit,
 		Difficulty: big.NewInt(1),
 		Alloc:      types.GenesisAlloc{},
 		ExtraData:  extraData,
@@ -113,7 +113,7 @@ func TestWorkerCheckPreCommitXDPoSMismatch(t *testing.T) {
 	defer chain.Stop()
 
 	worker := &worker{
-		config:      config,
+		chainConfig: config,
 		engine:      engine,
 		chain:       chain,
 		announceTxs: true,

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -27,7 +27,7 @@ const (
 	MinGasLimit          uint64 = 5000               // Minimum the gas limit may ever be.
 	MaxGasLimit          uint64 = 0x7fffffffffffffff // Maximum the gas limit (2^63-1).
 	GenesisGasLimit      uint64 = 4712388            // Gas limit of the Genesis block.
-	XDCGenesisGasLimit   uint64 = 84000000
+	XDCGenesisGasLimit   uint64 = 42000000
 
 	MaximumExtraDataSize  uint64 = 32    // Maximum size extra data may be after Genesis.
 	ExpByteGas            uint64 = 10    // Times ceil(log256(exponent)) for the EXP instruction.
@@ -173,8 +173,6 @@ var (
 	GenesisDifficulty      = big.NewInt(131072) // Difficulty of the Genesis block.
 	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
 	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
-
-	TargetGasLimit uint64 = XDCGenesisGasLimit // The artificial target
 )
 
 // System contracts.


### PR DESCRIPTION
# Proposed changes

Miner configuration is unified under [Eth.Miner] (GasCeil/GasPrice/Etherbase/ExtraData), replacing legacy top-level [Eth] miner keys.

Operational impact: 
existing config files using [Eth].GasPrice/[Eth].Etherbase/[Eth].ExtraData must be migrated before upgrade.

Behavior update: 
gasprice=0 remains valid; only negative gas prices are sanitized at startup.

Default change: 
XDCGenesisGasLimit is reduced to 42,000,000 and now feeds miner default GasCeil (including default --miner-gaslimit), so nodes relying on defaults should review capacity expectations.

Ref: #19480

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [X] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
