### PR TITLE
fix(params): accept legacy foudationwalletaddr in chain config, fix #2063

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -18,6 +18,7 @@ package params
 
 import (
 	"cmp"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"math/big"
@@ -558,6 +559,40 @@ type XDPoSConfig struct {
 	FoundationWalletAddr common.Address `json:"foundationWalletAddr"` // Foundation Address Wallet
 	SkipV1Validation     bool           //Skip Block Validation for testing purpose, V1 consensus only
 	V2                   *V2            `json:"v2"`
+}
+
+// UnmarshalJSON supports both the current and legacy typo-ed JSON key for
+// foundation wallet address to keep old on-disk chain configs compatible.
+func (c *XDPoSConfig) UnmarshalJSON(data []byte) error {
+	type xdpJSON struct {
+		Period                    uint64         `json:"period"`
+		Epoch                     uint64         `json:"epoch"`
+		Reward                    uint64         `json:"reward"`
+		RewardCheckpoint          uint64         `json:"rewardCheckpoint"`
+		Gap                       uint64         `json:"gap"`
+		FoundationWalletAddr      common.Address `json:"foundationWalletAddr"`
+		LegacyFoudationWalletAddr common.Address `json:"foudationWalletAddr"`
+		SkipV1Validation          bool           `json:"SkipV1Validation"`
+		V2                        *V2            `json:"v2"`
+	}
+	var decoded xdpJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	c.Period = decoded.Period
+	c.Epoch = decoded.Epoch
+	c.Reward = decoded.Reward
+	c.RewardCheckpoint = decoded.RewardCheckpoint
+	c.Gap = decoded.Gap
+	c.FoundationWalletAddr = decoded.FoundationWalletAddr
+	if c.FoundationWalletAddr == (common.Address{}) && decoded.LegacyFoudationWalletAddr != (common.Address{}) {
+		c.FoundationWalletAddr = decoded.LegacyFoudationWalletAddr
+	}
+	c.SkipV1Validation = decoded.SkipV1Validation
+	c.V2 = decoded.V2
+
+	return nil
 }
 
 type V2 struct {

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -17,10 +17,12 @@
 package params
 
 import (
+	"encoding/json"
 	"math/big"
 	"reflect"
 	"testing"
 
+	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -149,4 +151,22 @@ func TestSwitchEpoch(t *testing.T) {
 	config = TestXDPoSMockChainConfig.XDPoS
 	epoch = config.Epoch
 	assert.Equal(t, config.V2.SwitchEpoch, config.V2.SwitchBlock.Uint64()/epoch)
+}
+
+func TestXDPoSConfigUnmarshalLegacyFoundationWalletAddr(t *testing.T) {
+	const raw = `{"period":2,"epoch":900,"reward":5000,"rewardCheckpoint":900,"gap":450,"foudationWalletAddr":"xdc746249c61f5832c5eed53172776b460491bdcd5c"}`
+
+	var cfg XDPoSConfig
+	err := json.Unmarshal([]byte(raw), &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, common.HexToAddress("xdc746249c61f5832c5eed53172776b460491bdcd5c"), cfg.FoundationWalletAddr)
+}
+
+func TestXDPoSConfigUnmarshalFoundationWalletAddrPrecedence(t *testing.T) {
+	const raw = `{"period":2,"epoch":900,"reward":5000,"rewardCheckpoint":900,"gap":450,"foudationWalletAddr":"xdc746249c61f5832c5eed53172776b460491bdcd5c","foundationWalletAddr":"xdc92a289fe95a85c53b8d0d113cbaef0c1ec98ac65"}`
+
+	var cfg XDPoSConfig
+	err := json.Unmarshal([]byte(raw), &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, common.HexToAddress("xdc92a289fe95a85c53b8d0d113cbaef0c1ec98ac65"), cfg.FoundationWalletAddr)
 }


### PR DESCRIPTION
# Proposed changes

Add backward-compatible XDPoSConfig JSON decoding for the legacy key "foudationWalletAddr" introduced in PR #2063 renamed it to "foundationWalletAddr".

Without this compatibility layer, old on-disk chain configs are decoded with a zero FoundationWalletAddr, causing XDPoSConfigEqual mismatch and startup rewind ("mismatching XDPoS not equal in database").

This patch:
- Implements custom UnmarshalJSON for XDPoSConfig that reads both keys.
- Prefers foundationWalletAddr when both keys are present.
- Keeps existing behavior for all other fields.
- Adds regression tests for legacy-key decoding and precedence.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
