### PR TITLE
perf(core/txpool): use the cached address in ValidateTransactionWithState #30208

### DIFF
--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -177,7 +177,7 @@ type ValidationOptionsWithState struct {
 // rules without duplicating code and running the risk of missed updates.
 func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, opts *ValidationOptionsWithState) error {
 	// Ensure the transaction adheres to nonce ordering
-	from, err := signer.Sender(tx) // already validated (and cached), but cleaner to check
+	from, err := types.Sender(signer, tx) // already validated (and cached), but cleaner to check
 	if err != nil {
 		log.Error("Transaction sender recovery failed", "err", err)
 		return err


### PR DESCRIPTION
# Proposed changes

The address recover is executed and cached in ValidateTransaction already. It's expected that the cached one is returned in ValidateTransaction. However, currently, we use the wrong function signer.Sender instead of types.Sender which will do all the address recover again.

Ref: #30208

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [X] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
