### PR TITLE
refactor(eth): remove duplicated chain config source #19344

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -57,7 +57,7 @@ func (api *EthereumAPI) Mining() bool {
 
 func (api *EthereumAPI) ChainId() hexutil.Uint64 {
 	chainID := new(big.Int)
-	if config := api.e.chainConfig; config.IsEIP155(api.e.blockchain.CurrentBlock().Number) {
+	if config := api.e.blockchain.Config(); config.IsEIP155(api.e.blockchain.CurrentBlock().Number) {
 		chainID = config.ChainID
 	}
 	return (hexutil.Uint64)(chainID.Uint64())

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -63,7 +63,7 @@ type EthAPIBackend struct {
 }
 
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
-	return b.eth.chainConfig
+	return b.eth.blockchain.Config()
 }
 
 func (b *EthAPIBackend) CurrentBlock() *types.Header {
@@ -85,7 +85,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
-		if b.eth.chainConfig.XDPoS == nil {
+		if b.eth.blockchain.Config().XDPoS == nil {
 			return nil, errors.New("PoW does not support confirmed block lookup")
 		}
 		current := b.eth.blockchain.CurrentBlock()
@@ -138,7 +138,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
-		if b.eth.chainConfig.XDPoS == nil {
+		if b.eth.blockchain.Config().XDPoS == nil {
 			return nil, errors.New("PoW does not support confirmed block lookup")
 		}
 		current := b.eth.blockchain.CurrentBlock()
@@ -273,7 +273,7 @@ func (b *EthAPIBackend) GetEVM(ctx context.Context, state *state.StateDB, XDCxSt
 	} else {
 		context = core.NewEVMBlockContext(header, b.eth.BlockChain(), nil)
 	}
-	return vm.NewEVM(context, state, XDCxState, b.eth.chainConfig, *vmConfig), vmError, nil
+	return vm.NewEVM(context, state, XDCxState, b.eth.blockchain.Config(), *vmConfig), vmError, nil
 }
 
 func (b *EthAPIBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -27,7 +27,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/internal/ethapi"
-	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
 	"github.com/XinFinOrg/XDPoSChain/trie"
@@ -36,14 +35,13 @@ import (
 // DebugAPI is the collection of Ethereum full node APIs exposed over
 // the private debugging endpoint.
 type DebugAPI struct {
-	config *params.ChainConfig
-	eth    *Ethereum
+	eth *Ethereum
 }
 
 // NewDebugAPI creates a new API definition for the full node-related
 // private debug methods of the Ethereum service.
-func NewDebugAPI(config *params.ChainConfig, eth *Ethereum) *DebugAPI {
-	return &DebugAPI{config: config, eth: eth}
+func NewDebugAPI(eth *Ethereum) *DebugAPI {
+	return &DebugAPI{eth: eth}
 }
 
 // DumpBlock retrieves the entire state of the database at a given block.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -65,8 +65,7 @@ import (
 
 // Ethereum implements the Ethereum full node service.
 type Ethereum struct {
-	config      *ethconfig.Config
-	chainConfig *params.ChainConfig
+	config *ethconfig.Config
 
 	// Channel for shutting down the service
 	shutdownChan chan bool // Channel for shutting down the ethereum
@@ -146,7 +145,6 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	eth := &Ethereum{
 		config:         config,
 		chainDb:        chainDb,
-		chainConfig:    chainConfig,
 		eventMux:       stack.EventMux(),
 		accountManager: stack.AccountManager(),
 		engine:         CreateConsensusEngine(stack, chainConfig, chainDb),
@@ -221,7 +219,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 		}
 		vmConfig.Tracer = t
 	}
-	if eth.chainConfig.XDPoS != nil {
+	if chainConfig.XDPoS != nil {
 		c := eth.engine.(*XDPoS.XDPoS)
 		c.GetXDCXService = func() utils.TradingService {
 			return eth.XDCX
@@ -285,7 +283,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
 	var xdPoS *XDPoS.XDPoS = nil
-	if eth.chainConfig.XDPoS != nil {
+	if chainConfig.XDPoS != nil {
 		xdPoS = eth.engine.(*XDPoS.XDPoS)
 	}
 	eth.APIBackend = &EthAPIBackend{
@@ -303,7 +301,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	// Set global ipc endpoint.
 	eth.blockchain.IPCEndpoint = stack.IPCEndpoint()
 
-	if eth.chainConfig.XDPoS != nil {
+	if chainConfig.XDPoS != nil {
 		c := eth.engine.(*XDPoS.XDPoS)
 		signHook := func(block *types.Block) error {
 			eb, err := eth.Etherbase()
@@ -315,7 +313,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 			if !ok {
 				return nil
 			}
-			if block.NumberU64()%common.MergeSignRange == 0 || !eth.chainConfig.IsTIP2019(block.Number()) {
+			if block.NumberU64()%common.MergeSignRange == 0 || !chainConfig.IsTIP2019(block.Number()) {
 				if err := contracts.CreateTransactionSign(chainConfig, eth.txPool, eth.accountManager, block, chainDb, eb); err != nil {
 					return fmt.Errorf("fail to create tx sign for importing block: %v", err)
 				}
@@ -433,7 +431,7 @@ func (e *Ethereum) APIs() []rpc.API {
 			Service:   NewAdminAPI(e),
 		}, {
 			Namespace: "debug",
-			Service:   NewDebugAPI(e.chainConfig, e),
+			Service:   NewDebugAPI(e),
 		}, {
 			Namespace: "net",
 			Service:   e.netRPCService,
@@ -483,7 +481,7 @@ func (e *Ethereum) ValidateMasternode() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if e.chainConfig.XDPoS != nil {
+	if e.blockchain.Config().XDPoS != nil {
 		//check if miner's wallet is in set of validators
 		c := e.engine.(*XDPoS.XDPoS)
 


### PR DESCRIPTION
# Proposed changes

Drop Ethereum.chainConfig and consistently read chain configuration from blockchain.Config() to avoid dual sources of truth.

Changes include API/backend call sites and DebugAPI constructor cleanup. No functional behavior change is intended.

Ref: #19344

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [X] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
