### PR TITLE
fix(eth): initialize engine with finalized chain config, fix #2138

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -129,11 +129,11 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	if err != nil {
 		return nil, err
 	}
-	// Here we determine genesis hash and active ChainConfig.
-	// We need these to figure out the consensus parameters and to set up history pruning.
-	chainConfig, _, err := core.LoadChainConfig(chainDb, config.Genesis)
-	if err != nil {
-		return nil, err
+	// Resolve the effective chain config (and persist it when compatible)
+	// before constructing the consensus engine so it initializes with final network settings.
+	chainConfig, _, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
+	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
+		return nil, genesisErr
 	}
 
 	// Set networkID to chainID by default.
@@ -142,6 +142,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 		networkID = chainConfig.ChainID.Uint64()
 	}
 	common.CopyConstants(networkID)
+	engine := CreateConsensusEngine(stack, chainConfig, chainDb)
 
 	// Assemble the Ethereum object.
 	eth := &Ethereum{
@@ -149,7 +150,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 		chainDb:        chainDb,
 		eventMux:       stack.EventMux(),
 		accountManager: stack.AccountManager(),
-		engine:         CreateConsensusEngine(stack, chainConfig, chainDb),
+		engine:         engine,
 		shutdownChan:   make(chan bool),
 		networkId:      networkID,
 		gasPrice:       config.Miner.GasPrice,

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/XinFinOrg/XDPoSChain/core"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/eth/util"
 	"github.com/XinFinOrg/XDPoSChain/params"
 )
@@ -26,4 +28,66 @@ func TestRewardInflation(t *testing.T) {
 			t.Error("Fail tor calculate reward inflation above 6 years", "chainReward", chainReward)
 		}
 	}
+}
+
+func TestSetupGenesisBlockRepairsMissingV2Config(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+
+	legacyGenesis := legacyTestnetGenesisWithoutV2()
+	legacyGenesis.MustCommit(db)
+
+	loadedCfg, _, err := core.LoadChainConfig(db, core.DefaultTestnetGenesisBlock())
+	if err != nil {
+		t.Fatalf("LoadChainConfig failed: %v", err)
+	}
+	if loadedCfg.XDPoS == nil {
+		t.Fatal("expected XDPoS config in loaded chain config")
+	}
+	if loadedCfg.XDPoS.V2 != nil {
+		t.Fatal("expected stored legacy chain config to have nil XDPoS.V2 before setup")
+	}
+
+	finalCfg, _, err := core.SetupGenesisBlock(db, core.DefaultTestnetGenesisBlock())
+	if err != nil {
+		t.Fatalf("SetupGenesisBlock failed: %v", err)
+	}
+	if finalCfg.XDPoS == nil || finalCfg.XDPoS.V2 == nil {
+		t.Fatal("expected SetupGenesisBlock to return a config with XDPoS.V2")
+	}
+	if finalCfg.XDPoS.V2.SwitchBlock.Cmp(params.TestnetChainConfig.XDPoS.V2.SwitchBlock) != 0 {
+		t.Fatalf("unexpected switch block after setup: have %v want %v", finalCfg.XDPoS.V2.SwitchBlock, params.TestnetChainConfig.XDPoS.V2.SwitchBlock)
+	}
+}
+
+func TestSetupGenesisBlockIsIdempotentForTestnet(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	genesis := core.DefaultTestnetGenesisBlock()
+
+	cfg1, hash1, err := core.SetupGenesisBlock(db, genesis)
+	if err != nil {
+		t.Fatalf("first SetupGenesisBlock failed: %v", err)
+	}
+	cfg2, hash2, err := core.SetupGenesisBlock(db, genesis)
+	if err != nil {
+		t.Fatalf("second SetupGenesisBlock failed: %v", err)
+	}
+	if hash1 != hash2 {
+		t.Fatalf("genesis hash changed across SetupGenesisBlock calls: first %v second %v", hash1, hash2)
+	}
+	if cfg1.XDPoS == nil || cfg2.XDPoS == nil || cfg1.XDPoS.V2 == nil || cfg2.XDPoS.V2 == nil {
+		t.Fatal("expected both returned configs to include XDPoS.V2")
+	}
+	if cfg1.XDPoS.V2.SwitchBlock.Cmp(cfg2.XDPoS.V2.SwitchBlock) != 0 {
+		t.Fatalf("switch block changed across SetupGenesisBlock calls: first %v second %v", cfg1.XDPoS.V2.SwitchBlock, cfg2.XDPoS.V2.SwitchBlock)
+	}
+}
+
+func legacyTestnetGenesisWithoutV2() *core.Genesis {
+	legacyGenesis := *core.DefaultTestnetGenesisBlock()
+	legacyChainConfig := *params.TestnetChainConfig
+	legacyXDPoS := *params.TestnetChainConfig.XDPoS
+	legacyXDPoS.V2 = nil
+	legacyChainConfig.XDPoS = &legacyXDPoS
+	legacyGenesis.Config = &legacyChainConfig
+	return &legacyGenesis
 }


### PR DESCRIPTION
# Proposed changes

Reorder initialization in eth.New so the effective chain config is resolved and persisted via core.SetupGenesisBlock before creating the consensus engine.

Background:
- On first sync from genesis, LoadChainConfig could return a stored/incomplete config (notably with XDPoS.V2 unset in legacy testnet setups).
- Creating XDPoS before finalizing genesis config could trigger mainnet V2 fallback and log/behavior mismatches around SwitchBlock.

Proof:
Add a log in function `func (x *XDPoS) VerifyHeaders`:

```go
	log.Info("VerifyHeaders",
		"switch block in chain config", chain.Config().XDPoS.V2.SwitchBlock.Uint64(),
		"switch block in V2 config", x.config.V2.SwitchBlock.Uint64(),
	)
```

Result:
```text
"switch block in chain config"=56,828,700 "switch block in V2 config"=80,370,000
```

What changed:
- Replace early LoadChainConfig usage with SetupGenesisBlock in eth.New.
- Keep ConfigCompatError semantics consistent with core/blockchain initialization: fail only on non-compat errors.
- Initialize consensus engine after finalized chainConfig is available.

Result:
- Consensus engine now starts with finalized network config on first boot.
- Avoids incorrect V2 fallback parameters (e.g. wrong SwitchBlock) during initial testnet sync.

Tests:
- Added regression tests in eth/backend_test.go to cover legacy missing-V2 repair and SetupGenesisBlock idempotency.

fix #2138 

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
