### PR TITLE
ci(workflow): update Slack notification conditions for PR readiness

### DIFF
--- a/.github/workflows/pr-notify-slack.yml
+++ b/.github/workflows/pr-notify-slack.yml
@@ -1,10 +1,10 @@
-# Notify Slack when a PR is ready for review (not draft, title does not contain WIP).
-# Triggers: new PR (non-draft, no WIP), draft -> ready, or title edited to remove WIP.
+# Notify Slack when a PR is ready for review (not draft, no WIP label).
+# Triggers: new PR (non-draft, no WIP label), draft -> ready, or WIP label removed.
 name: PR notify Slack
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, edited]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, unlabeled]
   workflow_dispatch:
 
 jobs:
@@ -28,16 +28,13 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
-      !contains(github.event.pull_request.title, 'WIP') &&
+      !contains(github.event.pull_request.labels.*.name, 'WIP') &&
       (
-        github.event.action != 'edited' ||
+        github.event.action != 'unlabeled' ||
         (
-          github.event.changes.title &&
-          (
-            contains(github.event.changes.title.from, 'WIP')
-          )
+          github.event.label &&
+          github.event.label.name == 'WIP'
         )
       )
     steps:


### PR DESCRIPTION
# Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
