### PR TITLE
ci: fix grabbing the wrong PR link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,17 +170,13 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK_URL }}
         REPO: ${{ github.repository }}
       run: |
-        # Look up the merged PR that contains this commit
-        PR_JSON=$(curl -s -H "Authorization: Bearer ${GH_TOKEN}" \
-          "https://api.github.com/repos/${REPO}/commits/${GITHUB_SHA}/pulls")
+        # Extract PR number from merge commit message, e.g. "refactor(core): remove locals #30559 (#2176)"
+        # Matches the last (#NNNN) pattern to get your repo's PR, not the upstream reference
+        PR_NUMBER=$(git log -1 --format='%s' | grep -oP '\(#\K[0-9]+(?=\))' | tail -1 || true)
 
-        PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number // empty')
-        PR_URL=$(echo "$PR_JSON" | jq -r '.[0].html_url // empty')
-
+        PR_LINE="Commit: <https://github.com/${REPO}/commit/${GITHUB_SHA}|${GITHUB_SHA::7}>"
         if [ -n "$PR_NUMBER" ]; then
-          PR_LINE="Merged PR: <${PR_URL}|#${PR_NUMBER}>"
-        else
-          PR_LINE="Commit: <https://github.com/${REPO}/commit/${GITHUB_SHA}|${GITHUB_SHA::7}>"
+          PR_LINE+=$'\nMerged PR: <https://github.com/'"${REPO}"'/pull/'"${PR_NUMBER}"'|#'"${PR_NUMBER}"'>'
         fi
 
         curl -X POST -H 'Content-type: application/json' \


### PR DESCRIPTION
# Proposed changes
fix grabbing the wrong PR link

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [x] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [x] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
