### PR TITLE
fix(internal/ethapi): skip tx gas limit check for calls #32641

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -149,8 +149,12 @@ type Message struct {
 	// This field will be set to true for operations like RPC eth_call.
 	SkipNonceChecks bool
 
-	// When SkipFromEOACheck is true, the message sender is not checked to be an EOA.
-	SkipFromEOACheck bool
+	// When set, the message is not treated as a transaction, and certain
+	// transaction-specific checks are skipped:
+	//
+	// - From is not verified to be an EOA
+	// - GasLimit is not checked against the protocol defined tx gaslimit
+	SkipTransactionChecks bool
 }
 
 // TransactionToMessage converts a transaction into a Message.
@@ -167,7 +171,7 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, balanceFee, blo
 		AccessList:            tx.AccessList(),
 		SetCodeAuthorizations: tx.SetCodeAuthorizations(),
 		SkipNonceChecks:       false,
-		SkipFromEOACheck:      false,
+		SkipTransactionChecks: false,
 		BalanceTokenFee:       balanceFee,
 	}
 
@@ -317,7 +321,12 @@ func (st *StateTransition) preCheck() error {
 				msg.From.Hex(), stNonce)
 		}
 	}
-	if !msg.SkipFromEOACheck {
+	isOsaka := st.evm.ChainConfig().IsOsaka(st.evm.Context.BlockNumber)
+	if !msg.SkipTransactionChecks {
+		// Verify tx gas limit does not exceed EIP-7825 cap.
+		if isOsaka && msg.GasLimit > params.MaxTxGas {
+			return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
+		}
 		// Make sure the sender is an EOA
 		code := st.state.GetCode(msg.From)
 		_, delegated := types.ParseDelegation(code)
@@ -358,10 +367,6 @@ func (st *StateTransition) preCheck() error {
 		if len(msg.SetCodeAuthorizations) == 0 {
 			return fmt.Errorf("%w (sender %v)", ErrEmptyAuthList, msg.From)
 		}
-	}
-	// Verify tx gas limit does not exceed EIP-7825 cap.
-	if st.evm.ChainConfig().IsOsaka(st.evm.Context.BlockNumber) && msg.GasLimit > params.MaxTxGas {
-		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
 	}
 	return st.buyGas()
 }

--- a/core/token_validator.go
+++ b/core/token_validator.go
@@ -87,17 +87,17 @@ func CallContractWithState(call ethereum.CallMsg, chain consensus.ChainContext, 
 
 	// Execute the call.
 	msg := &Message{
-		From:             call.From,
-		To:               call.To,
-		Value:            call.Value,
-		GasLimit:         call.Gas,
-		GasPrice:         call.GasPrice,
-		GasFeeCap:        call.GasFeeCap,
-		GasTipCap:        call.GasTipCap,
-		Data:             call.Data,
-		AccessList:       call.AccessList,
-		SkipNonceChecks:  true,
-		SkipFromEOACheck: true,
+		From:                  call.From,
+		To:                    call.To,
+		Value:                 call.Value,
+		GasLimit:              call.Gas,
+		GasPrice:              call.GasPrice,
+		GasFeeCap:             call.GasFeeCap,
+		GasTipCap:             call.GasTipCap,
+		Data:                  call.Data,
+		AccessList:            call.AccessList,
+		SkipNonceChecks:       true,
+		SkipTransactionChecks: true,
 	}
 	feeCapacity := statedb.GetTRC21FeeCapacityFromState()
 	if msg.To != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -858,7 +858,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		return nil, err
 	}
 	var (
-		msg         = args.ToMessage(api.backend, vmctx.BaseFee, true, true)
+		msg         = args.ToMessage(api.backend, vmctx.BaseFee, true)
 		tx          = args.ToTransaction(types.LegacyTxType)
 		traceConfig *TraceConfig
 	)

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -969,17 +969,17 @@ func (b *Backend) callContract(ctx context.Context, call ethereum.CallMsg, block
 
 	// Execute the call.
 	msg := &core.Message{
-		From:             call.From,
-		To:               call.To,
-		Value:            call.Value,
-		GasLimit:         call.Gas,
-		GasPrice:         call.GasPrice,
-		GasFeeCap:        call.GasFeeCap,
-		GasTipCap:        call.GasTipCap,
-		Data:             call.Data,
-		AccessList:       call.AccessList,
-		SkipNonceChecks:  true,
-		SkipFromEOACheck: true,
+		From:                  call.From,
+		To:                    call.To,
+		Value:                 call.Value,
+		GasLimit:              call.Gas,
+		GasPrice:              call.GasPrice,
+		GasFeeCap:             call.GasFeeCap,
+		GasTipCap:             call.GasTipCap,
+		Data:                  call.Data,
+		AccessList:            call.AccessList,
+		SkipNonceChecks:       true,
+		SkipTransactionChecks: true,
 	}
 	feeCapacity := stateDB.GetTRC21FeeCapacityFromState()
 	if msg.To != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1129,10 +1129,10 @@ func doCall(ctx context.Context, b Backend, args TransactionArgs, state *state.S
 	// Make sure the context is cancelled when the call has completed
 	// this makes sure resources are cleaned up.
 	defer cancel()
-	return applyMessage(ctx, b, args, state, block, timeout, new(core.GasPool).AddGas(globalGasCap), &blockCtx, &vm.Config{NoBaseFee: true}, precompiles, true)
+	return applyMessage(ctx, b, args, state, block, timeout, new(core.GasPool).AddGas(globalGasCap), &blockCtx, &vm.Config{NoBaseFee: true}, precompiles)
 }
 
-func applyMessage(ctx context.Context, b Backend, args TransactionArgs, state *state.StateDB, block *types.Block, timeout time.Duration, gp *core.GasPool, blockContext *vm.BlockContext, vmConfig *vm.Config, precompiles vm.PrecompiledContracts, skipChecks bool) (*core.ExecutionResult, error) {
+func applyMessage(ctx context.Context, b Backend, args TransactionArgs, state *state.StateDB, block *types.Block, timeout time.Duration, gp *core.GasPool, blockContext *vm.BlockContext, vmConfig *vm.Config, precompiles vm.PrecompiledContracts) (*core.ExecutionResult, error) {
 	header := block.Header()
 	author, err := b.Engine().Author(header)
 	if err != nil {
@@ -1147,7 +1147,7 @@ func applyMessage(ctx context.Context, b Backend, args TransactionArgs, state *s
 	if err := args.CallDefaults(gp.Gas(), blockContext.BaseFee, b.ChainConfig().ChainID); err != nil {
 		return nil, err
 	}
-	msg := args.ToMessage(b, header.BaseFee, skipChecks, skipChecks)
+	msg := args.ToMessage(b, header.BaseFee, true)
 	msg.BalanceTokenFee = new(big.Int).SetUint64(msg.GasLimit)
 	msg.BalanceTokenFee.Mul(msg.BalanceTokenFee, msg.GasPrice)
 	// Lower the basefee to 0 to avoid breaking EVM
@@ -1287,7 +1287,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	if err := args.CallDefaults(gasCap, estimationHeader.BaseFee, b.ChainConfig().ChainID); err != nil {
 		return 0, err
 	}
-	call := args.ToMessage(b, estimationHeader.BaseFee, true, true)
+	call := args.ToMessage(b, estimationHeader.BaseFee, true)
 
 	// Run the gas estimation andwrap any revertals into a custom return
 	estimate, revert, err := gasestimator.Estimate(ctx, call, opts, gasCap)
@@ -1763,7 +1763,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		statedb := db.Copy()
 		// Set the accesslist to the last al
 		args.AccessList = &accessList
-		msg := args.ToMessage(b, header.BaseFee, true, true)
+		msg := args.ToMessage(b, header.BaseFee, true)
 
 		feeCapacity := statedb.GetTRC21FeeCapacityFromState()
 		var balanceTokenFee *big.Int

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -201,7 +201,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		txes[i] = tx
 		tracer.reset(tx.Hash(), uint(i))
 		// EoA check is always skipped, even in validation mode.
-		msg := call.ToMessage(sim.b, header.BaseFee, !sim.validate, true)
+		msg := call.ToMessage(sim.b, header.BaseFee, !sim.validate)
 		evm.SetTxContext(core.NewEVMTxContext(msg))
 		result, err := applyMessageWithEVM(ctx, evm, msg, timeout, sim.gp)
 		if err != nil {

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -291,7 +291,7 @@ func (args *TransactionArgs) CallDefaults(globalGasCap uint64, baseFee *big.Int,
 // ToMessage converts the transaction arguments to the Message type used by the
 // core evm. This method is used in calls and traces that do not require a real
 // live transaction.
-func (args *TransactionArgs) ToMessage(b AccountBackend, baseFee *big.Int, skipNonceCheck, skipEoACheck bool) *core.Message {
+func (args *TransactionArgs) ToMessage(b AccountBackend, baseFee *big.Int, skipNonceCheck bool) *core.Message {
 	var (
 		gasPrice  *big.Int
 		gasFeeCap *big.Int
@@ -347,7 +347,7 @@ func (args *TransactionArgs) ToMessage(b AccountBackend, baseFee *big.Int, skipN
 		AccessList:            accessList,
 		SetCodeAuthorizations: args.AuthorizationList,
 		SkipNonceChecks:       skipNonceCheck,
-		SkipFromEOACheck:      skipEoACheck,
+		SkipTransactionChecks: true,
 	}
 }
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -341,7 +341,7 @@ func (tx *stTransaction) toMessage(ps stPostState, baseFee *big.Int) (*core.Mess
 		AccessList:            accessList,
 		SetCodeAuthorizations: authList,
 		SkipNonceChecks:       false,
-		SkipFromEOACheck:      false,
+		SkipTransactionChecks: false,
 	}
 	return msg, nil
 }


### PR DESCRIPTION
# Proposed changes

This disables the tx gaslimit cap for eth_call and related RPC operations.

eth_call, estimateGas, simulate and tracer paths construct Message values that do not represent a mempool transaction.

This change consolidates skip semantics by replacing SkipFromEOACheck with SkipTransactionChecks and enabling it for call-style execution paths.

Impact:
- Avoids applying EIP-7825 tx gas-limit validation to non-transaction call contexts.
- Preserves transaction-path validation for normal block processing and txpool flows.
- Keeps behavior aligned across internal/ethapi, tracers, simulated backend, and state tests.
- 
Ref: #32641

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
