### PR TITLE
fix(core): fix TestStateProcessorErrors wrong error under Osaka/Prague

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -19,6 +19,7 @@ package core
 import (
 	"crypto/ecdsa"
 	"encoding/binary"
+	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -126,15 +127,36 @@ func TestStateProcessorErrors(t *testing.T) {
 					},
 				},
 			}
-			genesis        = gspec.MustCommit(db)
-			blockchain, _  = NewBlockChain(db, nil, gspec, ethash.NewFaker(), vm.Config{})
-			tooBigInitCode = [params.MaxInitCodeSize + 1]byte{}
+			genesis       = gspec.MustCommit(db)
+			blockchain, _ = NewBlockChain(db, nil, gspec, ethash.NewFaker(), vm.Config{})
 		)
 
 		defer blockchain.Stop()
+		num := big.NewInt(1)
+		rules := config.Rules(num)
 		bigNumber := new(big.Int).SetBytes(common.MaxHash.Bytes())
 		tooBigNumber := new(big.Int).Set(bigNumber)
 		tooBigNumber.Add(tooBigNumber, common.Big1)
+		maxInitCodeSize := params.MaxInitCodeSize
+		if rules.IsOsaka {
+			maxInitCodeSize = params.MaxInitCodeSizeOsaka
+		}
+		tooBigInitCode := make([]byte, maxInitCodeSize+1)
+		tooBigInitCodeIntrinsicGas, err := IntrinsicGas(tooBigInitCode, nil, nil, true, rules.IsHomestead, rules.IsEIP1559)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tooBigInitCodeRequiredGas := tooBigInitCodeIntrinsicGas
+		if rules.IsPrague {
+			tooBigInitCodeFloorGas, err := FloorDataGas(tooBigInitCode)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tooBigInitCodeFloorGas > tooBigInitCodeRequiredGas {
+				tooBigInitCodeRequiredGas = tooBigInitCodeFloorGas
+			}
+		}
+		tooBigInitCodeTx := mkDynamicCreationTx(0, tooBigInitCodeRequiredGas+1000, common.Big0, big.NewInt(params.InitialBaseFee), tooBigInitCode)
 		gasLimit := blockchain.CurrentHeader().GasLimit
 		for i, tt := range []struct {
 			txs  []*types.Transaction
@@ -236,9 +258,9 @@ func TestStateProcessorErrors(t *testing.T) {
 			},
 			{ // ErrMaxInitCodeSizeExceeded
 				txs: []*types.Transaction{
-					mkDynamicCreationTx(0, 520000, common.Big0, big.NewInt(params.InitialBaseFee), tooBigInitCode[:]),
+					tooBigInitCodeTx,
 				},
-				want: "could not apply tx 0 [0x41d48b664cf891e625a16696a90e892ba3857c0b5ea759c3f2bdb4158338cb85]: max initcode size exceeded: code size 49153 limit 49152",
+				want: fmt.Sprintf("could not apply tx 0 [%s]: max initcode size exceeded: code size %d limit %d", tooBigInitCodeTx.Hash().Hex(), len(tooBigInitCode), maxInitCodeSize),
 			},
 			{ // ErrIntrinsicGas: Not enough gas to cover init code
 				txs: []*types.Transaction{


### PR DESCRIPTION
# Proposed changes

The max-initcode-size test case started failing after Osaka/Prague rules are active.

Instead of returning ErrMaxInitCodeSizeExceeded, the test hit earlier gas validations (notably floor data gas), making the assertion brittle.

Update the test to build an oversize initcode payload based on the active fork limits and set gas high enough to pass prerequisite gas checks, so the intended max initcode size error is asserted consistently.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
