### PR TITLE
fix(miner): fix min tip filtering across basefee boundary

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -145,7 +145,7 @@ type worker struct {
 	mu       sync.Mutex
 	coinbase common.Address
 	extra    []byte
-	tip      *uint256.Int // Minimum tip needed for non-local transaction to include them
+	tip      *uint256.Int // Configured minimum gas-price threshold for including transactions in mined blocks.
 
 	snapshotMu       sync.RWMutex // The lock used to protect the block snapshot and state snapshot
 	snapshotBlock    *types.Block
@@ -255,6 +255,47 @@ func (w *worker) pendingBlock() *types.Block {
 	w.snapshotMu.RLock()
 	defer w.snapshotMu.RUnlock()
 	return w.snapshotBlock
+}
+
+// pendingMinTipForHeader converts the configured minimum gas price into the
+// minimum tip required by txpool pending filtering for the given header.
+//
+// With base fee enabled, txpool filters by effective tip, not effective gas
+// price. To preserve the configured minimum gas price semantics, we derive:
+//
+//	minTip = max(minGasPrice - baseFee, 0)
+func pendingMinTipForHeader(minGasPrice *uint256.Int, baseFee *uint256.Int) *uint256.Int {
+	minTip := new(uint256.Int)
+	if minGasPrice != nil {
+		minTip.Set(minGasPrice)
+	}
+	if baseFee == nil {
+		return minTip
+	}
+	if minTip.Cmp(baseFee) <= 0 {
+		minTip.SetUint64(0)
+		return minTip
+	}
+	return minTip.Sub(minTip, baseFee)
+}
+
+// pendingFilterForHeader builds a txpool pending filter using the miner min
+// gas price semantics for the provided header.
+func pendingFilterForHeader(minGasPrice *uint256.Int, header *types.Header, chainConfig *params.ChainConfig) txpool.PendingFilter {
+	var baseFee *uint256.Int
+	if header.BaseFee != nil {
+		baseFee = uint256.MustFromBig(header.BaseFee)
+	}
+	filter := txpool.PendingFilter{
+		MinTip: pendingMinTipForHeader(minGasPrice, baseFee),
+	}
+	if baseFee != nil {
+		filter.BaseFee = baseFee
+	}
+	if chainConfig.IsOsaka(header.Number) {
+		filter.GasLimitCap = params.MaxTxGas
+	}
+	return filter
 }
 
 // pendingBlockAndReceipts returns pending block and corresponding receipts.
@@ -862,15 +903,10 @@ func (w *worker) commitNewWork() {
 		}
 		if !isEpochSwitchBlock {
 			// Retrieve the pending transactions pre-filtered by the 1559 dynamic fees
-			filter := txpool.PendingFilter{
-				MinTip: w.tip,
-			}
-			if header.BaseFee != nil {
-				filter.BaseFee = uint256.MustFromBig(header.BaseFee)
-			}
-			if w.chainConfig.IsOsaka(header.Number) {
-				filter.GasLimitCap = params.MaxTxGas
-			}
+			// w.tip is the configured minimum gas-price threshold (historical name),
+			// not an EIP-1559 priority-fee tip.
+			minGasPrice := w.tip
+			filter := pendingFilterForHeader(minGasPrice, header, w.chainConfig)
 			pending := w.eth.TxPool().Pending(filter)
 			txs, specialTxs = newTransactionsByPriceAndNonce(w.current.signer, pending, feeCapacity, header.BaseFee)
 		}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -17,6 +17,7 @@
 package miner
 
 import (
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
@@ -26,8 +27,11 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/txpool"
+	"github.com/XinFinOrg/XDPoSChain/core/txpool/legacypool"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/holiman/uint256"
@@ -172,4 +176,201 @@ func TestWorkerSetGasTipCopiesValue(t *testing.T) {
 	if w.tip.Cmp(uint256.NewInt(2*params.GWei)) != 0 {
 		t.Fatalf("worker tip mutated via input pointer: have %v", w.tip)
 	}
+}
+
+func TestPendingMinTipForHeaderWithoutBaseFee(t *testing.T) {
+	minGasPrice := uint256.NewInt(12_500_000_000)
+	got := pendingMinTipForHeader(minGasPrice, nil)
+
+	if got.Cmp(minGasPrice) != 0 {
+		t.Fatalf("unexpected min tip without baseFee: have %v want %v", got, minGasPrice)
+	}
+}
+
+func TestPendingMinTipForHeaderBaseFeeEqualsMinGasPrice(t *testing.T) {
+	minGasPrice := uint256.NewInt(12_500_000_000)
+	baseFee := uint256.NewInt(12_500_000_000)
+
+	got := pendingMinTipForHeader(minGasPrice, baseFee)
+	want := uint256.NewInt(0)
+
+	if got.Cmp(want) != 0 {
+		t.Fatalf("unexpected min tip when baseFee equals min gas price: have %v want %v", got, want)
+	}
+}
+
+func TestPendingMinTipForHeaderSubtractsBaseFee(t *testing.T) {
+	minGasPrice := uint256.NewInt(12_500_000_001)
+	baseFee := uint256.NewInt(12_500_000_000)
+
+	got := pendingMinTipForHeader(minGasPrice, baseFee)
+	want := uint256.NewInt(1)
+
+	if got.Cmp(want) != 0 {
+		t.Fatalf("unexpected min tip after baseFee subtraction: have %v want %v", got, want)
+	}
+}
+
+func TestPendingFilterForHeaderBaseFeeBoundary(t *testing.T) {
+	header := &types.Header{
+		Number:  big.NewInt(1),
+		BaseFee: big.NewInt(12_500_000_000),
+	}
+	minGasPrice := uint256.NewInt(12_500_000_000)
+
+	filter := pendingFilterForHeader(minGasPrice, header, &params.ChainConfig{})
+
+	if filter.MinTip == nil || filter.MinTip.Cmp(uint256.NewInt(0)) != 0 {
+		t.Fatalf("unexpected min tip at boundary: have %v want 0", filter.MinTip)
+	}
+	if filter.BaseFee == nil || filter.BaseFee.Cmp(uint256.MustFromBig(header.BaseFee)) != 0 {
+		t.Fatalf("unexpected base fee in filter: have %v want %v", filter.BaseFee, header.BaseFee)
+	}
+}
+
+func TestPendingFilterForHeaderWithoutBaseFee(t *testing.T) {
+	header := &types.Header{
+		Number: big.NewInt(1),
+	}
+	minGasPrice := uint256.NewInt(12_500_000_000)
+
+	filter := pendingFilterForHeader(minGasPrice, header, &params.ChainConfig{})
+
+	if filter.MinTip == nil || filter.MinTip.Cmp(minGasPrice) != 0 {
+		t.Fatalf("unexpected min tip without baseFee: have %v want %v", filter.MinTip, minGasPrice)
+	}
+	if filter.BaseFee != nil {
+		t.Fatalf("expected nil base fee in filter, have %v", filter.BaseFee)
+	}
+}
+
+func TestPendingFilterForHeaderGasLimitCapPreOsaka(t *testing.T) {
+	header := &types.Header{
+		Number:  big.NewInt(1),
+		BaseFee: big.NewInt(12_500_000_000),
+	}
+	minGasPrice := uint256.NewInt(12_500_000_000)
+	// With default chain config (Osaka not activated), GasLimitCap should remain zero.
+	filter := pendingFilterForHeader(minGasPrice, header, &params.ChainConfig{})
+	if filter.GasLimitCap != 0 {
+		t.Fatalf("unexpected gas limit cap before Osaka activation: have %v want %v", filter.GasLimitCap, 0)
+	}
+}
+
+func TestPendingFilterForHeaderGasLimitCapOsaka(t *testing.T) {
+	header := &types.Header{
+		Number:  big.NewInt(1),
+		BaseFee: big.NewInt(12_500_000_000),
+	}
+	minGasPrice := uint256.NewInt(12_500_000_000)
+	// Activate Osaka at block 1 so that this header is considered Osaka.
+	cfg := &params.ChainConfig{
+		OsakaBlock: big.NewInt(1),
+	}
+	filter := pendingFilterForHeader(minGasPrice, header, cfg)
+	if filter.GasLimitCap != params.MaxTxGas {
+		t.Fatalf("unexpected gas limit cap after Osaka activation: have %v want %v", filter.GasLimitCap, params.MaxTxGas)
+	}
+}
+
+func TestPendingFilterForHeaderTxPoolBoundarySelection(t *testing.T) {
+	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	if err != nil {
+		t.Fatalf("failed to create test key: %v", err)
+	}
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	to := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	chainConfig := params.MergedTestChainConfig
+	baseFee := big.NewInt(params.InitialBaseFee)
+	genesis := &core.Genesis{
+		Config: chainConfig,
+		Alloc: types.GenesisAlloc{
+			from: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+		},
+		Difficulty: common.Big0,
+		BaseFee:    new(big.Int).Set(baseFee),
+	}
+
+	db := rawdb.NewMemoryDatabase()
+	engine := ethash.NewFaker()
+	chain, err := core.NewBlockChain(db, nil, genesis, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create blockchain: %v", err)
+	}
+	defer chain.Stop()
+
+	legacyCfg := legacypool.DefaultConfig
+	legacyCfg.Journal = ""
+	legacyPool := legacypool.New(legacyCfg, chain)
+	txPool, err := txpool.New(legacyCfg.PriceLimit, chain, []txpool.SubPool{legacyPool})
+	if err != nil {
+		t.Fatalf("failed to create txpool: %v", err)
+	}
+	defer func() {
+		if err := txPool.Close(); err != nil {
+			t.Errorf("failed to close txpool: %v", err)
+		}
+	}()
+
+	signer := types.LatestSignerForChainID(chainConfig.ChainID)
+	legacyTx := mustSignLegacyTx(t, key, signer, 0, new(big.Int).Set(baseFee), to)
+	dynamicTx := mustSignDynamicBoundaryTx(t, key, signer, chainConfig.ChainID, 1, new(big.Int).Set(baseFee), to)
+
+	errs := txPool.Add([]*types.Transaction{legacyTx, dynamicTx}, true)
+	for i, addErr := range errs {
+		if addErr != nil {
+			t.Fatalf("failed to add tx %d: %v", i, addErr)
+		}
+	}
+
+	pendingAll, _ := txPool.ContentFrom(from)
+	if len(pendingAll) != 2 {
+		t.Fatalf("unexpected pending tx count after add: have %d want 2", len(pendingAll))
+	}
+
+	header := &types.Header{Number: big.NewInt(1), BaseFee: new(big.Int).Set(baseFee)}
+	minGasPrice := uint256.MustFromBig(baseFee)
+
+	filter := pendingFilterForHeader(minGasPrice, header, chainConfig)
+	selected := txPool.Pending(filter)
+	if got := len(selected[from]); got != 2 {
+		t.Fatalf("boundary txs should be selected with derived min tip: have %d want 2", got)
+	}
+
+	// This mirrors the pre-fix behavior (MinTip=minGasPrice with baseFee present),
+	// which over-filters boundary-valid transactions.
+	legacyBehaviorFilter := txpool.PendingFilter{MinTip: minGasPrice, BaseFee: uint256.MustFromBig(baseFee)}
+	legacySelected := txPool.Pending(legacyBehaviorFilter)
+	if got := len(legacySelected[from]); got != 0 {
+		t.Fatalf("pre-fix filter unexpectedly selected boundary txs: have %d want 0", got)
+	}
+}
+
+func mustSignLegacyTx(t *testing.T, key *ecdsa.PrivateKey, signer types.Signer, nonce uint64, gasPrice *big.Int, to common.Address) *types.Transaction {
+	t.Helper()
+	tx := types.NewTransaction(nonce, to, big.NewInt(1), params.TxGas, gasPrice, nil)
+	signed, err := types.SignTx(tx, signer, key)
+	if err != nil {
+		t.Fatalf("failed to sign legacy tx: %v", err)
+	}
+	return signed
+}
+
+func mustSignDynamicBoundaryTx(t *testing.T, key *ecdsa.PrivateKey, signer types.Signer, chainID *big.Int, nonce uint64, baseFee *big.Int, to common.Address) *types.Transaction {
+	t.Helper()
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   new(big.Int).Set(chainID),
+		Nonce:     nonce,
+		GasTipCap: big.NewInt(params.GWei),
+		GasFeeCap: new(big.Int).Set(baseFee),
+		Gas:       params.TxGas,
+		To:        &to,
+		Value:     big.NewInt(1),
+	})
+	signed, err := types.SignTx(tx, signer, key)
+	if err != nil {
+		t.Fatalf("failed to sign dynamic fee tx: %v", err)
+	}
+	return signed
 }


### PR DESCRIPTION
# Proposed changes

Miner block assembly previously passed the configured min gas price directly as PendingFilter.MinTip when baseFee was present. Because txpool compares effective tip under EIP-1559 rules, this could incorrectly exclude boundary-valid transactions where effective tip is zero (for example legacy gasPrice == baseFee and equivalent dynamic-fee boundary cases).

This change derives the pending filter tip as max(minGasPrice - baseFee, 0), preserving the intended minimum gas-price policy both with and without baseFee. It also centralizes pending filter construction in pendingFilterForHeader and clarifies that w.tip represents the configured min gas-price threshold.

Regression coverage now includes no-baseFee behavior, boundary equality, subtraction path, Osaka gas-limit-cap branches, and a txpool-backed boundary-selection test to validate call-site wiring.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
