### PR TITLE
fix(eth/gasestimator): cap osaka estimate hi at maxtxgas #32348

### DIFF
--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -60,6 +60,20 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 	if call.GasLimit >= params.TxGas {
 		hi = call.GasLimit
 	}
+
+	// Cap the maximum gas allowance according to EIP-7825 if the estimation targets Osaka
+	if hi > params.MaxTxGas {
+		blockNumber := opts.Header.Number
+		if opts.BlockOverrides != nil {
+			if opts.BlockOverrides.Number != nil {
+				blockNumber = opts.BlockOverrides.Number.ToInt()
+			}
+		}
+		if opts.Config.IsOsaka(blockNumber) {
+			hi = params.MaxTxGas
+		}
+	}
+
 	// Normalize the max fee per gas the call is willing to spend.
 	var feeCap *big.Int
 	if call.GasFeeCap != nil {

--- a/eth/gasestimator/gasestimator_test.go
+++ b/eth/gasestimator/gasestimator_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package gasestimator
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
+	"github.com/XinFinOrg/XDPoSChain/core"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/state"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+type testChainContext struct {
+	engine consensus.Engine
+}
+
+func (c *testChainContext) Engine() consensus.Engine {
+	return c.engine
+}
+
+func (c *testChainContext) GetHeader(common.Hash, uint64) *types.Header {
+	return nil
+}
+
+func TestEstimateCapsHiAtMaxTxGasOnOsaka(t *testing.T) {
+	t.Parallel()
+
+	from := common.HexToAddress("0x1001")
+	to := common.HexToAddress("0x1002")
+
+	genesis := &core.Genesis{
+		Config: params.MergedTestChainConfig,
+		Alloc: types.GenesisAlloc{
+			from: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	db := rawdb.NewMemoryDatabase()
+	block := genesis.MustCommit(db)
+
+	stateDB, err := state.New(block.Root(), state.NewDatabase(db))
+	if err != nil {
+		t.Fatalf("failed to create state db: %v", err)
+	}
+
+	header := types.CopyHeader(block.Header())
+	header.GasLimit = params.MaxTxGas + 100000
+
+	opts := &Options{
+		Config: params.MergedTestChainConfig,
+		Chain:  &testChainContext{engine: ethash.NewFaker()},
+		Header: header,
+		State:  stateDB,
+	}
+	msg := &core.Message{
+		From:                  from,
+		To:                    &to,
+		Nonce:                 0,
+		Value:                 new(big.Int),
+		GasLimit:              header.GasLimit,
+		GasPrice:              new(big.Int),
+		GasFeeCap:             new(big.Int),
+		GasTipCap:             new(big.Int),
+		SkipNonceChecks:       false,
+		SkipTransactionChecks: false,
+	}
+
+	estimate, _, err := Estimate(context.Background(), msg, opts, 0)
+	if err != nil {
+		t.Fatalf("estimate should not fail when hi is capped at maxTxGas: %v", err)
+	}
+	if estimate > params.MaxTxGas {
+		t.Fatalf("estimate exceeds maxTxGas: got %d, max %d", estimate, params.MaxTxGas)
+	}
+}


### PR DESCRIPTION
# Proposed changes

Cap Estimate gas upper bound to params.MaxTxGas when Osaka rules apply, so the initial execution path cannot start above the EIP-7825 transaction gas cap.

Add TestEstimateCapsHiAtMaxTxGasOnOsaka to lock this behavior and prevent regressions where estimation would fail with transaction gas limit too high.

Ref: #32348

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [X] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
