### PR TITLE
fix(cmd/XDC,internal/cmdtest): stabilize flaky unlock timeout

### DIFF
--- a/cmd/XDC/accountcmd_test.go
+++ b/cmd/XDC/accountcmd_test.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cespare/cp"
 )
@@ -352,6 +353,7 @@ func TestUnlockFlagAmbiguousWrongPassword(t *testing.T) {
 	XDC := runXDC(t,
 		"--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0", "--nousb", "--cache", "128", "--ipcdisable",
 		"--keystore", store, "--unlock", "f466859ead1932d743d622cb74fc058882e8648a")
+	XDC.KillTimeout = 90 * time.Second
 	defer XDC.ExpectExit()
 
 	// Helper for the expect template, returns absolute keystore path.

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -51,6 +51,9 @@ type TestCmd struct {
 	stdout *bufio.Reader
 	stdin  io.WriteCloser
 	stderr *testlogger
+	// KillTimeout controls how long expect/wait helpers wait before killing child.
+	// Zero value falls back to the historical default.
+	KillTimeout time.Duration
 	// Err will contain the process exit error or interrupt signal error
 	Err error
 }
@@ -230,7 +233,11 @@ func (tt *TestCmd) Kill() {
 }
 
 func (tt *TestCmd) withKillTimeout(fn func()) {
-	timeout := time.AfterFunc(30*time.Second, func() {
+	killTimeout := tt.KillTimeout
+	if killTimeout <= 0 {
+		killTimeout = 30 * time.Second
+	}
+	timeout := time.AfterFunc(killTimeout, func() {
 		tt.Log("killing the child process (timeout)")
 		tt.Kill()
 	})


### PR DESCRIPTION
# Proposed changes

Make cmdtest kill timeout configurable per test while keeping 30s default.\nSet 90s timeout for TestUnlockFlagAmbiguousWrongPassword to avoid intermittent startup-related timeout failures.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
