### PR TITLE
fix(core/txpool): fix error `pool attempted to unreserve non-reserved address`

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -740,7 +740,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 			// by a return statement before running deferred methods. Take care with
 			// removing or subscoping err as it will break this clause.
 			if err != nil {
-				pool.reserver.Release(from)
+				pool.releaseReservation(from)
 			}
 		}()
 	}
@@ -1120,6 +1120,19 @@ func (pool *LegacyPool) get(hash common.Hash) *types.Transaction {
 	return pool.all.Get(hash)
 }
 
+type ownerReserver interface {
+	Owns(common.Address) bool
+}
+
+func (pool *LegacyPool) releaseReservation(addr common.Address) {
+	if ownerAware, ok := pool.reserver.(ownerReserver); ok {
+		if !ownerAware.Owns(addr) {
+			return
+		}
+	}
+	_ = pool.reserver.Release(addr)
+}
+
 // Has returns an indicator whether txpool has a transaction cached with the
 // given hash.
 func (pool *LegacyPool) Has(hash common.Hash) bool {
@@ -1153,7 +1166,7 @@ func (pool *LegacyPool) removeTx(hash common.Hash, outofbound bool, unreserve bo
 				_, hasQueued  = pool.queue.get(addr)
 			)
 			if !hasPending && !hasQueued {
-				pool.reserver.Release(addr)
+				pool.releaseReservation(addr)
 			}
 		}()
 	}
@@ -1511,7 +1524,7 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 	for _, addr := range removedAddresses {
 		_, hasPending := pool.pending[addr]
 		if !hasPending {
-			pool.reserver.Release(addr)
+			pool.releaseReservation(addr)
 		}
 	}
 	return promoted
@@ -1611,7 +1624,7 @@ func (pool *LegacyPool) truncateQueue() {
 	for _, addr := range removedAddresses {
 		_, hasPending := pool.pending[addr]
 		if !hasPending {
-			pool.reserver.Release(addr)
+			pool.releaseReservation(addr)
 		}
 	}
 }
@@ -1676,7 +1689,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			delete(pool.pending, addr)
 			pendingAddrsGauge.Dec(1)
 			if _, ok := pool.queue.get(addr); !ok {
-				pool.reserver.Release(addr)
+				pool.releaseReservation(addr)
 			}
 		}
 	}
@@ -1932,11 +1945,11 @@ func (pool *LegacyPool) Clear() {
 	// acquire the subpool lock until the transaction addition is completed.
 	for addr := range pool.pending {
 		if _, ok := pool.queue.get(addr); !ok {
-			pool.reserver.Release(addr)
+			pool.releaseReservation(addr)
 		}
 	}
 	for _, addr := range pool.queue.addresses() {
-		pool.reserver.Release(addr)
+		pool.releaseReservation(addr)
 	}
 	pool.all.Clear()
 	pool.priced.Reheap()

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -244,6 +244,13 @@ func (r *reserver) Has(address common.Address) bool {
 	return false // reserver only supports a single pool
 }
 
+func (r *reserver) Owns(address common.Address) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	_, exists := r.accounts[address]
+	return exists
+}
+
 func setupPoolWithConfig(config *params.ChainConfig) (*LegacyPool, *ecdsa.PrivateKey) {
 	diskdb := rawdb.NewMemoryDatabase()
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(diskdb))
@@ -489,6 +496,47 @@ func TestPromoteSpecialTxOverflowReturnsErrorWithoutMutation(t *testing.T) {
 	}
 	if pool.pendingNonces.get(addr) != 0 {
 		t.Fatalf("pending nonce changed for rejected special tx: have %d want 0", pool.pendingNonces.get(addr))
+	}
+}
+
+func TestPromoteExecutablesQueueEmptyWithoutReservation(t *testing.T) {
+	t.Parallel()
+
+	diskdb := rawdb.NewMemoryDatabase()
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(diskdb))
+	chain := newTestBlockChain(params.TestChainConfig, 10000000, statedb, new(event.Feed))
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	statedb.AddBalance(addr, big.NewInt(1_000_000_000_000_000), tracing.BalanceChangeUnspecified)
+
+	r := &reserver{accounts: make(map[common.Address]struct{})}
+	pool := New(testTxPoolConfig, chain)
+	if err := pool.Init(testTxPoolConfig.PriceLimit, chain.CurrentBlock(), r); err != nil {
+		t.Fatalf("failed to init pool: %v", err)
+	}
+	defer pool.Close()
+	<-pool.initDoneCh
+
+	queuedTx := pricedTransaction(5, 100000, new(big.Int).Add(new(big.Int).Set(common.MinGasPrice), big.NewInt(1)), key)
+	if err := pool.addRemoteSync(queuedTx); err != nil {
+		t.Fatalf("failed to add queued tx: %v", err)
+	}
+
+	r.lock.Lock()
+	delete(r.accounts, addr)
+	r.lock.Unlock()
+
+	pool.mu.Lock()
+	pool.currentState.SetNonce(addr, 10)
+	pool.promoteExecutables([]common.Address{addr})
+	pool.mu.Unlock()
+
+	if _, ok := pool.queue.get(addr); ok {
+		t.Fatal("queue should be empty after stale tx is dropped")
 	}
 }
 

--- a/core/txpool/reserver.go
+++ b/core/txpool/reserver.go
@@ -136,3 +136,12 @@ func (h *ReservationHandle) Has(address common.Address) bool {
 	id, exists := h.tracker.accounts[address]
 	return exists && id != h.id
 }
+
+// Owns reports whether this handle currently owns the reservation for address.
+func (h *ReservationHandle) Owns(address common.Address) bool {
+	h.tracker.lock.RLock()
+	defer h.tracker.lock.RUnlock()
+
+	id, exists := h.tracker.accounts[address]
+	return exists && id == h.id
+}


### PR DESCRIPTION
# Proposed changes

Symptom:

Nodes may repeatedly log "pool attempted to unreserve non-reserved address" during chain import, especially when queue cleanup runs after account state changes. Such as:

```text
ERROR[03-27|12:31:22.238] pool attempted to unreserve non-reserved address address=0xb6c1f9dA410d0739efBE934b4c30dFBEE2755233
ERROR[03-27|12:31:26.073] pool attempted to unreserve non-reserved address address=0xb6c1f9dA410d0739efBE934b4c30dFBEE2755233
ERROR[03-27|12:31:36.284] pool attempted to unreserve non-reserved address address=0xb6c1f9dA410d0739efBE934b4c30dFBEE2755233
ERROR[03-27|12:31:56.081] pool attempted to unreserve non-reserved address address=0xb6c1f9dA410d0739efBE934b4c30dFBEE2755233
ERROR[03-27|12:32:10.068] pool attempted to unreserve non-reserved address address=0xb6c1f9dA410d0739efBE934b4c30dFBEE2755233
```

Cause:

The failure happens on block-by-block cleanup paths (notably queue-empty handling during promoteExecutables). Since block import repeatedly triggers these cleanup checks, the same address can be evaluated every round. Without an ownership guard, each round may attempt another Release for the same address and emit the same error again.

Address presence in pending/queue and reservation ownership are tracked by different states. Cleanup decisions are based on pending/queue emptiness, while ownership is tracked by the reservation tracker. If ownership was already released (or otherwise no longer held) earlier, a later cleanup round can still satisfy the pending/queue condition and attempt Release again, producing an ownership mismatch.

LegacyPool cleanup paths can call Release on addresses that are no longer owned by the current subpool, creating a reservation ownership mismatch.

Fix:

Add an ownership guard before releasing reservations, so legacypool only releases addresses it still owns. Keep release behavior unchanged for valid ownership cases.

Validation:

Add and keep a focused regression test covering the queue-empty-without-reservation scenario, and verify legacypool package tests pass.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
