### PR TITLE
chore(pre-commit,docs): scope hooks by stage and improve dev guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,40 @@
 fail_fast: true
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-        args: []
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
+        stages: [pre-commit]
       - id: end-of-file-fixer
+        stages: [pre-commit]
       - id: check-json
+        stages: [pre-commit]
       - id: check-yaml
+        stages: [pre-commit]
       - id: check-toml
+        stages: [pre-commit]
       - id: check-symlinks
+        stages: [pre-commit]
       - id: fix-byte-order-marker
+        stages: [pre-commit]
       - id: check-added-large-files
+        stages: [pre-commit]
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:
       - id: go-fmt
+        stages: [pre-commit]
       - id: go-vet
+        stages: [pre-commit]
       - id: go-imports
+        stages: [pre-commit]
       - id: go-mod-tidy
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: make-generate
@@ -31,3 +42,4 @@ repos:
         entry: make generate
         language: system
         pass_filenames: false
+        stages: [pre-commit]

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,14 +1,101 @@
-# How to setup development environment
+# How to set up the development environment
 
 ## pre-commit
+
+### Install pre-commit
+
+Install pre-commit via `pipx`:
 
 ```bash
 # Install pre-commit
 pipx install pre-commit
 
-# Install git hook
+# Verify installed version
+pre-commit --version
+```
+
+### Upgrade pre-commit
+
+If pre-commit was installed via `pipx`, upgrade it with:
+
+```bash
+# Upgrade pre-commit
+pipx upgrade pre-commit
+
+# Verify installed version
+pre-commit --version
+```
+
+### Install Git hooks
+
+Install Git hook scripts:
+
+```bash
+# Install the pre-commit hook
 pre-commit install
 
-# Uninstall git hook
+# Install the commit-msg hook
+pre-commit install --hook-type commit-msg
+
+# Validate pre-commit configuration
+pre-commit validate-config
+
+# Verify commit-msg hook (this does not create a commit)
+tmp_commit_msg="$(mktemp)"
+printf "chore(docs): test commit message\n" > "${tmp_commit_msg}"
+pre-commit run conventional-pre-commit --hook-stage commit-msg --commit-msg-filename "${tmp_commit_msg}"
+rm -f "${tmp_commit_msg}"
+```
+
+Note:
+
+- commit messages must follow Conventional Commits.
+  - Format: `<type>(<scope>): <description>`
+  - Example: `feat(core): add new validation check`
+- The above commands avoid scanning the whole repository. If you want to run hooks against the whole repository, use:
+
+```bash
+pre-commit run --all-files
+```
+
+This command only runs hooks in the `pre-commit` stage and may modify many files.
+
+### Upgrade hook versions
+
+Update hook versions in `.pre-commit-config.yaml`:
+
+```bash
+pre-commit autoupdate
+```
+
+After updating, prepare environments, run checks, and review changes before committing:
+
+```bash
+pre-commit install-hooks
+pre-commit validate-config
+tmp_commit_msg="$(mktemp)"
+printf "chore(docs): test commit message\n" > "${tmp_commit_msg}"
+pre-commit run conventional-pre-commit --hook-stage commit-msg --commit-msg-filename "${tmp_commit_msg}"
+rm -f "${tmp_commit_msg}"
+git diff .pre-commit-config.yaml
+```
+
+### Uninstall Git hooks
+
+Uninstall Git hook scripts:
+
+```bash
+# Uninstall the commit-msg hook
+pre-commit uninstall --hook-type commit-msg
+
+# Uninstall the pre-commit hook
 pre-commit uninstall
+```
+
+### Uninstall pre-commit
+
+Uninstall pre-commit with:
+
+```bash
+pipx uninstall pre-commit
 ```


### PR DESCRIPTION
# Proposed changes

Scope non-message hooks to the pre-commit stage and keep Conventional Commit checks in commit-msg only.

Update docs/develop.md to clarify install, verification, and upgrade flows with stage-specific commands.

Document safer verification details:

- pre-commit run --all-files is optional and can modify many files.
- commit-msg checks should use a temporary message file instead of relying on .git/COMMIT_EDITMSG.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [X] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
