### PR TITLE
fix(downloader): prevent infinite loop in reorg protection header delay

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -954,7 +954,15 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 						if delay > n {
 							delay = n
 						}
-						headers = headers[:n-delay]
+						// Only apply the delay if there are headers remaining after cutting.
+						// If delay == n, all headers would be removed and the downloader would
+						// loop forever retrying the same headers without making progress.
+						if n-delay > 0 {
+							p.log.Debug("[fetchHeaders] reorg protection delaying headers", "localHead", head, "lastHeaderNum", headers[n-1].Number.Uint64(), "threshold", reorgProtThreshold, "totalReceived", n, "delaying", delay, "remaining", n-delay)
+							headers = headers[:n-delay]
+						} else {
+							p.log.Debug("[fetchHeaders] reorg protection skipped: would remove all headers", "localHead", head, "lastHeaderNum", headers[n-1].Number.Uint64(), "threshold", reorgProtThreshold, "totalReceived", n)
+						}
 					}
 				}
 			}

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -1676,3 +1676,130 @@ func TestRemoteHeaderRequestSpan(t *testing.T) {
 		}
 	}
 }
+
+// Tests that synchronisation succeeds when the peer is slightly ahead but within
+// a range that triggers reorg protection AND causes the skeleton to fail (so
+// full-fetch mode is used, returning very few headers per request).
+//
+// This is a regression test for a bug introduced in ethereum/go-ethereum#17839:
+// when the peer is between (reorgProtThreshold, MaxHeaderFetch) blocks ahead,
+// the skeleton request returns 0 headers (peer doesn't have the skeleton range),
+// the downloader falls back to full-fetch. On the last batch only 1-2 headers
+// remain; the reorg-protection delay cuts ALL of them (delay=min(2,n)=n,
+// remaining=0), and the downloader retries every fsHeaderContCheck forever
+// without making progress.
+//
+// In production the bug manifested as a permanent stall because block insertion
+// was blocked by the BFT consensus engine (which itself waited for sync to
+// finish), keeping CurrentBlock low. We simulate that condition here by using
+// chainInsertHook to pause insertion long enough that CurrentBlock cannot
+// advance between header-fetch retries.
+//
+// Concretely: gap=51 matches the real-world scenario observed in production
+// (local=3,807,570, peer=3,807,621, localHead+48=3,807,618 < 3,807,621).
+func TestReorgProtectionDoesNotStallSync63Full(t *testing.T) {
+	testReorgProtectionDoesNotStallSync(t, 63, FullSync)
+}
+func TestReorgProtectionDoesNotStallSync64Full(t *testing.T) {
+	testReorgProtectionDoesNotStallSync(t, 64, FullSync)
+}
+
+func testReorgProtectionDoesNotStallSync(t *testing.T, protocol int, mode SyncMode) {
+	t.Parallel()
+
+	// All gaps are > reorgProtThreshold (48) so reorg protection fires on the
+	// last batch, but < MaxHeaderFetch (192) so the skeleton fails and
+	// full-fetch is used. The critical cases are gap=49 and gap=50 where the
+	// final batch has exactly 2 headers and delay=min(2,2)=2 cuts all of them.
+	gaps := []int{
+		reorgProtThreshold + 1,                        // 49: final batch = 2 headers, delay cuts all
+		reorgProtThreshold + 2,                        // 50: final batch = 2 headers, delay cuts all
+		reorgProtThreshold + reorgProtHeaderDelay + 1, // 51: the exact production scenario
+		MaxHeaderFetch - 1,                            // 191: just below skeleton threshold
+	}
+
+	for _, gap := range gaps {
+		gap := gap
+		t.Run(fmt.Sprintf("gap=%d", gap), func(t *testing.T) {
+			t.Parallel()
+
+			tester := newTester()
+			defer tester.terminate()
+
+			baseLen := blockCacheMaxItems - 15
+			peerChain := testChainBase.shorten(baseLen + gap)
+			localChain := testChainBase.shorten(baseLen)
+
+			// Pre-populate the tester's local chain with baseLen blocks so that
+			// CurrentBlock() returns the block at height baseLen-1.
+			tester.ownHashes = append(tester.ownHashes[:0], localChain.chain...)
+			for hash, header := range localChain.headerm {
+				tester.ownHeaders[hash] = header
+			}
+			for _, block := range localChain.blockm {
+				tester.ownBlocks[block.Hash()] = block
+				// Stub stateDb so CurrentBlock's lookup succeeds.
+				tester.stateDb.Put(block.Root().Bytes(), []byte{0x00})
+			}
+			// Do not copy receipts: FullSync doesn't download receipts, so
+			// assertOwnChain expects receipts == 1 (genesis only).
+			for hash, td := range localChain.tdm {
+				tester.ownChainTd[hash] = td
+			}
+
+			// Delay only the FIRST block-insertion call to keep CurrentBlock low
+			// while fetchHeaders makes its second header request. This reproduces
+			// the key condition of the bug:
+			//
+			//   1. fetchHeaders delivers a first batch (gap-2 headers).
+			//   2. fetchHeaders immediately retries; the last batch has only 2
+			//      headers. The reorg-protection check fires because
+			//      localHead+threshold < peerHead, and delay=min(2,2)=2 would
+			//      cut ALL remaining headers. Without the fix this causes a
+			//      fsHeaderContCheck retry loop that resolves only once
+			//      CurrentBlock advances – which requires the first insertion
+			//      batch to finish.
+			//   3. With insertDelay > fsHeaderContCheck the retry happens before
+			//      CurrentBlock can advance, so the loop iterates at least once.
+			//
+			// Only the first hook call sleeps; subsequent calls are instant.
+			// This avoids compounding delays when there are multiple insertion
+			// batches (e.g. gap=191 may produce two batches: 189 then 2 blocks).
+			//
+			// Timeline (D = insertDelay, R = fsHeaderContCheck):
+			//   WITHOUT fix: D (first insert) + R (one retry) = D + R
+			//   WITH fix:    D (first insert, all headers already queued) ≈ D
+			//
+			// timeout = D + R/2 sits between the two, so fix passes, bug fails.
+			insertDelay := 4 * fsHeaderContCheck         // e.g. 2 s
+			timeout := insertDelay + fsHeaderContCheck/2 // e.g. 2.25 s
+
+			var firstHookDone uint32
+			tester.downloader.chainInsertHook = func(_ []*fetchResult) {
+				if atomic.CompareAndSwapUint32(&firstHookDone, 0, 1) {
+					time.Sleep(insertDelay)
+				}
+			}
+
+			tester.newPeer("peer", protocol, peerChain)
+
+			done := make(chan error, 1)
+			go func() {
+				done <- tester.sync("peer", nil, mode)
+			}()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("sync failed (gap=%d, mode=%v): %v", gap, mode, err)
+				}
+			case <-time.After(timeout):
+				t.Fatalf("sync timed out after %v (gap=%d, mode=%v): "+
+					"reorg protection is cutting all headers on last batch and stalling the downloader",
+					timeout, gap, mode)
+			}
+
+			assertOwnChain(t, tester, peerChain.len())
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Add safety check to prevent reorg protection from removing all headers
during sync, which caused the downloader to stall indefinitely. When the
delay equals the number of available headers (delay == n), the downloader
would retry the same headers forever without making progress.

This bug manifested when a peer was slightly ahead (between
reorgProtThreshold and MaxHeaderFetch blocks), causing skeleton fetch to
fail and full-fetch mode to be used with very few headers per batch. On
the final batch with 1-2 headers remaining, reorg protection would cut
all headers, creating an infinite retry loop.

Changes:
- Skip header truncation when it would remove all headers (n-delay <= 0)
- Add debug logging for both applied and skipped reorg protection
- Add regression tests covering critical gap scenarios (49-191 blocks)
- Tests simulate production condition where block insertion is paused

This fixes a devnet issue observed at local block 3,807,570 with
peer at 3,807,621 (gap of 51 blocks).

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
