### PR TITLE
fix(internal/ethapi): limit eth_simulateV1 call count #34616

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1232,6 +1232,16 @@ func (api *BlockChainAPI) SimulateV1(ctx context.Context, opts simOpts, blockNrO
 	} else if len(opts.BlockStateCalls) > maxSimulateBlocks {
 		return nil, &clientLimitExceededError{message: "too many blocks"}
 	}
+	var totalCalls int
+	for i, block := range opts.BlockStateCalls {
+		if len(block.Calls) > maxSimulateCallsPerBlock {
+			return nil, &clientLimitExceededError{message: fmt.Sprintf("too many calls in block %d (max %d)", i, maxSimulateCallsPerBlock)}
+		}
+		totalCalls += len(block.Calls)
+		if totalCalls > maxSimulateTotalCalls {
+			return nil, &clientLimitExceededError{message: fmt.Sprintf("too many calls (max %d)", maxSimulateTotalCalls)}
+		}
+	}
 	if blockNrOrHash == nil {
 		n := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		blockNrOrHash = &n

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"hash"
 	"math/big"
 	"strings"
@@ -6647,4 +6648,42 @@ func TestSimulateV1TooManyBlocksByOverrideNumber(t *testing.T) {
 		{BlockOverrides: &override.BlockOverrides{Number: (*hexutil.Big)(tooFar)}},
 	})
 	require.ErrorContains(t, err, "too many blocks")
+}
+
+func TestSimulateV1CallLimitPerBlock(t *testing.T) {
+	t.Parallel()
+
+	api := NewBlockChainAPI(newBackendMock(), nil)
+
+	_, err := api.SimulateV1(context.Background(), simOpts{
+		BlockStateCalls: []simBlock{{
+			Calls: make([]TransactionArgs, maxSimulateCallsPerBlock+1),
+		}},
+	}, nil)
+	require.Error(t, err)
+	require.EqualError(t, err, fmt.Sprintf("too many calls in block %d (max %d)", 0, maxSimulateCallsPerBlock))
+
+	var rpcErr interface{ ErrorCode() int }
+	require.ErrorAs(t, err, &rpcErr)
+	require.Equal(t, errCodeClientLimitExceeded, rpcErr.ErrorCode())
+}
+
+func TestSimulateV1CallLimitTotal(t *testing.T) {
+	t.Parallel()
+
+	api := NewBlockChainAPI(newBackendMock(), nil)
+
+	_, err := api.SimulateV1(context.Background(), simOpts{
+		BlockStateCalls: []simBlock{
+			{Calls: make([]TransactionArgs, maxSimulateCallsPerBlock)},
+			{Calls: make([]TransactionArgs, maxSimulateCallsPerBlock)},
+			{Calls: make([]TransactionArgs, 1)},
+		},
+	}, nil)
+	require.Error(t, err)
+	require.EqualError(t, err, fmt.Sprintf("too many calls (max %d)", maxSimulateTotalCalls))
+
+	var rpcErr interface{ ErrorCode() int }
+	require.ErrorAs(t, err, &rpcErr)
+	require.Equal(t, errCodeClientLimitExceeded, rpcErr.ErrorCode())
 }

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -44,6 +44,14 @@ const (
 	// in a single request.
 	maxSimulateBlocks = 256
 
+	// maxSimulateCallsPerBlock is the maximum number of calls allowed in a
+	// single simulated block.
+	maxSimulateCallsPerBlock = 5000
+
+	// maxSimulateTotalCalls is the maximum total number of calls allowed
+	// across all simulated blocks in a single request.
+	maxSimulateTotalCalls = 10000
+
 	// timestampIncrement is the default increment between block timestamps.
 	timestampIncrement = 1
 )


### PR DESCRIPTION
# Proposed changes

Enforce per-block and total call limits for eth_simulateV1 requests and reject oversized payloads early with client limit errors.

Ref: #34616

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
