### PR TITLE
fix(eth/tracers): remove duplicate prague pre-call in parallel tracing, revert #2067

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -640,6 +640,9 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 // traceBlockParallel is for tracers that have a high overhead (read JS tracers). One thread
 // runs along and executes txes without tracing enabled to generate their prestate.
 // Worker threads take the tasks and the prestate and trace them.
+//
+// Precondition: callers must apply block-level pre-execution system calls (e.g. Prague
+// parent-hash processing) to statedb before entering this function.
 func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, statedb *state.StateDB, config *TraceConfig) ([]*txTraceResult, error) {
 	// Execute all the transaction contained within the block concurrently
 	var (
@@ -695,9 +698,6 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 	var failed error
 	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	evm := vm.NewEVM(blockCtx, statedb, nil, api.backend.ChainConfig(), vm.Config{})
-	if api.backend.ChainConfig().IsPrague(block.Number()) {
-		core.ProcessParentBlockHash(block.ParentHash(), evm)
-	}
 
 txloop:
 	for i, tx := range txs {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -19,7 +19,6 @@ package tracers
 import (
 	"context"
 	"crypto/ecdsa"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -297,75 +296,6 @@ func TestStateHooks(t *testing.T) {
 	}
 	if got.Storage[to][common.Hash{}] != common.HexToHash("0x2a") {
 		t.Fatalf("unexpected storage value: %v", got.Storage[to][common.Hash{}])
-	}
-}
-
-func TestTraceBlockParallelPragueParentHashSystemCall(t *testing.T) {
-	t.Parallel()
-
-	var (
-		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-		from   = crypto.PubkeyToAddress(key.PublicKey)
-		to     = common.HexToAddress("0x00000000000000000000000000000000deadbeef")
-		config = *params.TestChainConfig
-		nonce  = uint64(0)
-	)
-	config.Eip1559Block = big.NewInt(0)
-	config.PragueBlock = big.NewInt(0)
-
-	genesis := &core.Genesis{
-		Config: &config,
-		Alloc: types.GenesisAlloc{
-			from: {Balance: big.NewInt(params.Ether)},
-			to:   {Balance: big.NewInt(0)},
-		},
-	}
-
-	backend := newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
-		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
-			Nonce:    nonce,
-			To:       &to,
-			Value:    big.NewInt(1),
-			Gas:      params.TxGas,
-			GasPrice: b.BaseFee(),
-			Data:     nil,
-		}), types.HomesteadSigner{}, key)
-		b.AddTx(tx)
-		nonce++
-	})
-	defer backend.teardown()
-
-	api := NewAPI(backend)
-	block := backend.chain.GetBlockByNumber(1)
-	if block == nil {
-		t.Fatal("failed to retrieve test block")
-	}
-	parent := backend.chain.GetBlock(block.ParentHash(), block.NumberU64()-1)
-	if parent == nil {
-		t.Fatal("failed to retrieve parent block")
-	}
-	statedb, release, err := backend.StateAtBlock(context.Background(), parent, defaultTraceReexec, nil, true, false)
-	if err != nil {
-		t.Fatalf("failed to create parent state: %v", err)
-	}
-	defer release()
-
-	results, err := api.traceBlockParallel(context.Background(), block, statedb, nil)
-	if err != nil {
-		t.Fatalf("traceBlockParallel failed: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("unexpected result length: have %d want 1", len(results))
-	}
-	if results[0].Error != "" {
-		t.Fatalf("unexpected trace error: %v", results[0].Error)
-	}
-	var historyKey common.Hash
-	binary.BigEndian.PutUint64(historyKey[24:], (block.NumberU64()-1)%params.HistoryServeWindow)
-	have := statedb.GetState(params.HistoryStorageAddress, historyKey)
-	want := block.ParentHash()
-	if have != want {
-		t.Fatalf("unexpected parent hash in history storage: have %v want %v", have, want)
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

revert #2067

The Prague parent-hash system call is already executed in traceBlock before the JS tracer parallel path. Remove the duplicate call in traceBlockParallel to align with upstream behavior.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
