### PR TITLE
fix(consensus): fix error `invalid merkle root` on pre-tip-signing replay

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -234,7 +234,6 @@ func (x *XDPoS) VerifyHeaders(chain consensus.ChainReader, headers []*types.Head
 		}
 	}
 
-
 	if v1headers != nil {
 		x.EngineV1.VerifyHeaders(chain, v1headers, v1fullVerifies, abort, results)
 	}
@@ -514,21 +513,18 @@ Caching
 // Cache signing transaction data into BlockSingers cache object
 func (x *XDPoS) CacheNoneTIPSigningTxs(header *types.Header, txs []*types.Transaction, receipts []*types.Receipt) []*types.Transaction {
 	signTxs := []*types.Transaction{}
-	for _, tx := range txs {
+	for txIndex, tx := range txs {
 		if tx.IsSigningTransaction() {
-			var b uint64
-			for _, r := range receipts {
-				if r.TxHash == tx.Hash() {
-					if len(r.PostState) > 0 {
-						b = types.ReceiptStatusSuccessful
-					} else {
-						b = r.Status
-					}
-					break
-				}
+			receipt := findTransactionReceipt(txIndex, tx.Hash(), receipts)
+			if receipt == nil {
+				continue
 			}
 
-			if b == types.ReceiptStatusFailed {
+			status := receipt.Status
+			if len(receipt.PostState) > 0 {
+				status = types.ReceiptStatusSuccessful
+			}
+			if status == types.ReceiptStatusFailed {
 				continue
 			}
 
@@ -540,6 +536,21 @@ func (x *XDPoS) CacheNoneTIPSigningTxs(header *types.Header, txs []*types.Transa
 	x.signingTxsCache.Add(header.Hash(), signTxs)
 
 	return signTxs
+}
+
+func findTransactionReceipt(txIndex int, txHash common.Hash, receipts []*types.Receipt) *types.Receipt {
+	if txIndex < len(receipts) {
+		receipt := receipts[txIndex]
+		if receipt != nil && (receipt.TxHash == (common.Hash{}) || receipt.TxHash == txHash) {
+			return receipt
+		}
+	}
+	for _, receipt := range receipts {
+		if receipt != nil && receipt.TxHash == txHash {
+			return receipt
+		}
+	}
+	return nil
 }
 
 // Cache

--- a/consensus/XDPoS/XDPoS_test.go
+++ b/consensus/XDPoS/XDPoS_test.go
@@ -1,9 +1,12 @@
 package XDPoS
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,4 +18,89 @@ func TestAdaptorShouldShareDbWithV1Engine(t *testing.T) {
 
 	assert := assert.New(t)
 	assert.Equal(engine.EngineV1.GetDb(), engine.GetDb())
+}
+
+func TestCacheNoneTIPSigningTxsSupportsRawReceiptsWithoutTxHash(t *testing.T) {
+	database := rawdb.NewMemoryDatabase()
+	config := params.TestXDPoSMockChainConfig
+	engine := New(config, database)
+
+	signingTx := types.NewTransaction(
+		0,
+		common.BlockSignersBinary,
+		big.NewInt(0),
+		200000,
+		big.NewInt(0),
+		append(common.Hex2Bytes(common.HexSignMethod), make([]byte, 64)...),
+	)
+	normalTx := types.NewTransaction(
+		1,
+		common.Address{0x1},
+		big.NewInt(0),
+		21000,
+		big.NewInt(0),
+		nil,
+	)
+	receipts := []*types.Receipt{
+		{Status: types.ReceiptStatusSuccessful},
+		{Status: types.ReceiptStatusSuccessful},
+	}
+
+	cached := engine.CacheNoneTIPSigningTxs(&types.Header{Number: big.NewInt(1)}, []*types.Transaction{signingTx, normalTx}, receipts)
+
+	assert.Len(t, cached, 1)
+	assert.Equal(t, signingTx.Hash(), cached[0].Hash())
+}
+
+func TestCacheNoneTIPSigningTxsSkipsFailedSigningReceiptByIndex(t *testing.T) {
+	database := rawdb.NewMemoryDatabase()
+	config := params.TestXDPoSMockChainConfig
+	engine := New(config, database)
+
+	signingTx := types.NewTransaction(
+		0,
+		common.BlockSignersBinary,
+		big.NewInt(0),
+		200000,
+		big.NewInt(0),
+		append(common.Hex2Bytes(common.HexSignMethod), make([]byte, 64)...),
+	)
+	receipts := []*types.Receipt{{Status: types.ReceiptStatusFailed}}
+
+	cached := engine.CacheNoneTIPSigningTxs(&types.Header{Number: big.NewInt(1)}, []*types.Transaction{signingTx}, receipts)
+
+	assert.Empty(t, cached)
+}
+
+func TestCacheNoneTIPSigningTxsWithRawReceiptRoundTrip(t *testing.T) {
+	database := rawdb.NewMemoryDatabase()
+	config := params.TestXDPoSMockChainConfig
+	engine := New(config, database)
+	blockHash := common.HexToHash("0x1234")
+	blockNumber := uint64(1)
+
+	signingTx := types.NewTransaction(
+		0,
+		common.BlockSignersBinary,
+		big.NewInt(0),
+		200000,
+		big.NewInt(0),
+		append(common.Hex2Bytes(common.HexSignMethod), make([]byte, 64)...),
+	)
+	receipts := []*types.Receipt{{
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 200000,
+		TxHash:            signingTx.Hash(),
+	}}
+
+	rawdb.WriteReceipts(database, blockHash, blockNumber, receipts)
+	rawReceipts := rawdb.ReadRawReceipts(database, blockHash, blockNumber)
+
+	assert.Len(t, rawReceipts, 1)
+	assert.Equal(t, common.Hash{}, rawReceipts[0].TxHash)
+
+	cached := engine.CacheNoneTIPSigningTxs(&types.Header{Number: big.NewInt(int64(blockNumber))}, []*types.Transaction{signingTx}, rawReceipts)
+
+	assert.Len(t, cached, 1)
+	assert.Equal(t, signingTx.Hash(), cached[0].Hash())
 }

--- a/contracts/utils_test.go
+++ b/contracts/utils_test.go
@@ -27,11 +27,14 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind"
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind/backends"
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/contracts/blocksigner"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 var (
@@ -51,6 +54,50 @@ func getCommonBackend() *backends.SimulatedBackend {
 	backend.Commit()
 
 	return backend
+}
+
+type rewardReplayChain struct {
+	config  *params.ChainConfig
+	current *types.Header
+	headers map[uint64]*types.Header
+	blocks  map[uint64]*types.Block
+}
+
+func (c *rewardReplayChain) Config() *params.ChainConfig {
+	return c.config
+}
+
+func (c *rewardReplayChain) CurrentHeader() *types.Header {
+	return c.current
+}
+
+func (c *rewardReplayChain) GetHeader(hash common.Hash, number uint64) *types.Header {
+	header := c.headers[number]
+	if header == nil || header.Hash() != hash {
+		return nil
+	}
+	return header
+}
+
+func (c *rewardReplayChain) GetHeaderByNumber(number uint64) *types.Header {
+	return c.headers[number]
+}
+
+func (c *rewardReplayChain) GetHeaderByHash(hash common.Hash) *types.Header {
+	for _, header := range c.headers {
+		if header.Hash() == hash {
+			return header
+		}
+	}
+	return nil
+}
+
+func (c *rewardReplayChain) GetBlock(hash common.Hash, number uint64) *types.Block {
+	block := c.blocks[number]
+	if block == nil || block.Hash() != hash {
+		return nil
+	}
+	return block
 }
 
 func TestSendTxSign(t *testing.T) {
@@ -113,6 +160,109 @@ func TestSendTxSign(t *testing.T) {
 		if len(signers) != len(keys) {
 			t.Error("Tx sign for block validators not match")
 		}
+	}
+}
+
+func TestGetRewardForCheckpointReplaysSigningTxsFromRawReceipts(t *testing.T) {
+	database := rawdb.NewMemoryDatabase()
+	config := params.TestXDPoSMockChainConfig
+	engine := XDPoS.New(config, database)
+
+	checkpointExtra := append(bytes.Repeat([]byte{0x00}, utils.ExtraVanity), acc1Addr.Bytes()...)
+	checkpointExtra = append(checkpointExtra, make([]byte, utils.ExtraSeal)...)
+
+	checkpointHeader := types.NewBlock(&types.Header{
+		Number: big.NewInt(14),
+		Extra:  checkpointExtra,
+	}, nil, nil, nil, trie.NewStackTrie(nil))
+	block15 := types.NewBlock(&types.Header{
+		Number:     big.NewInt(15),
+		ParentHash: checkpointHeader.Hash(),
+	}, nil, nil, nil, trie.NewStackTrie(nil))
+	block16 := types.NewBlock(&types.Header{
+		Number:     big.NewInt(16),
+		ParentHash: block15.Hash(),
+	}, nil, nil, nil, trie.NewStackTrie(nil))
+
+	signer := types.MakeSigner(config, big.NewInt(17))
+	signingTx1, err := types.SignTx(CreateTxSign(big.NewInt(15), block15.Hash(), 0, common.BlockSignersBinary), signer, acc1Key)
+	if err != nil {
+		t.Fatalf("failed to sign first replay tx: %v", err)
+	}
+	receipts := []*types.Receipt{
+		{Status: types.ReceiptStatusSuccessful, CumulativeGasUsed: 200000, TxHash: signingTx1.Hash()},
+	}
+	replayBlock := types.NewBlock(&types.Header{
+		Number:     big.NewInt(17),
+		ParentHash: block16.Hash(),
+	}, []*types.Transaction{signingTx1}, nil, receipts, trie.NewStackTrie(nil))
+	rawdb.WriteReceipts(database, replayBlock.Hash(), replayBlock.NumberU64(), receipts)
+
+	rawReceipts := rawdb.ReadRawReceipts(database, replayBlock.Hash(), replayBlock.NumberU64())
+	if len(rawReceipts) != 1 {
+		t.Fatalf("unexpected raw receipt count: have %d want 1", len(rawReceipts))
+	}
+	if rawReceipts[0].TxHash != (common.Hash{}) {
+		t.Fatalf("expected raw receipt without TxHash metadata, got %s", rawReceipts[0].TxHash)
+	}
+	precheckCached := engine.CacheNoneTIPSigningTxs(replayBlock.Header(), replayBlock.Transactions(), rawReceipts)
+	if len(precheckCached) != 1 {
+		t.Fatalf("unexpected cached signing tx count from raw receipts: have %d want 1", len(precheckCached))
+	}
+	if from := precheckCached[0].From(); from == nil || *from != acc1Addr {
+		t.Fatalf("unexpected signer recovered from replay tx: have %v want %s", from, acc1Addr)
+	}
+	if got := common.BytesToHash(precheckCached[0].Data()[len(precheckCached[0].Data())-32:]); got != block15.Hash() {
+		t.Fatalf("unexpected first replay target hash: have %s want %s", got, block15.Hash())
+	}
+	masternodes := engine.GetMasternodesFromCheckpointHeader(checkpointHeader.Header())
+	if len(masternodes) != 1 || masternodes[0] != acc1Addr {
+		t.Fatalf("unexpected checkpoint masternodes: have %v want [%s]", masternodes, acc1Addr)
+	}
+
+	checkpointBlock := types.NewBlock(&types.Header{
+		Number:     big.NewInt(18),
+		ParentHash: replayBlock.Hash(),
+	}, nil, nil, nil, trie.NewStackTrie(nil))
+	engine = XDPoS.New(config, database)
+	chain := &rewardReplayChain{
+		config:  config,
+		current: checkpointBlock.Header(),
+		headers: map[uint64]*types.Header{
+			14: checkpointHeader.Header(),
+			15: block15.Header(),
+			16: block16.Header(),
+			17: replayBlock.Header(),
+			18: checkpointBlock.Header(),
+		},
+		blocks: map[uint64]*types.Block{
+			15: block15,
+			16: block16,
+			17: replayBlock,
+			18: checkpointBlock,
+		},
+	}
+	if _, ok := engine.GetCachedSigningTxs(replayBlock.Hash()); ok {
+		t.Fatal("expected empty signing cache before restart replay")
+	}
+
+	totalSigner := uint64(0)
+	signers, err := GetRewardForCheckpoint(engine, chain, checkpointBlock.Header(), 2, &totalSigner)
+	if err != nil {
+		t.Fatalf("GetRewardForCheckpoint returned error: %v", err)
+	}
+	if cached, ok := engine.GetCachedSigningTxs(replayBlock.Hash()); !ok || len(cached) != 1 {
+		t.Fatalf("expected replay block signing txs to be cached during reward replay, got ok=%v len=%d", ok, len(cached))
+	}
+	if totalSigner != 1 {
+		t.Fatalf("unexpected total signer count: have %d want 1", totalSigner)
+	}
+	rewardLog := signers[acc1Addr]
+	if rewardLog == nil {
+		t.Fatalf("expected signer %s to be reconstructed from replay", acc1Addr)
+	}
+	if rewardLog.Sign != 1 {
+		t.Fatalf("unexpected signer count for %s: have %d want 1", acc1Addr, rewardLog.Sign)
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

Symptom: nodes that resumed syncing from local state could fail checkpoint validation with an invalid merkle root while replaying pre-TIPSigning blocks after restart.

Cause: the non-TIP signing transaction replay path rebuilt signer data from raw receipts, but raw receipts may not carry TxHash metadata. As a result, signing transactions could be dropped and checkpoint rewards recalculated with totalSigner=0.

Fix: match non-TIP signing transactions to receipts by transaction index when receipt metadata is unavailable, keep the failed-receipt filter intact, and add regression tests covering both raw-receipt matching and end-to-end checkpoint reward replay through GetRewardForCheckpoint.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
