### PR TITLE
fix(eth): reorder ethereum shutdown sequence

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -580,16 +580,37 @@ func (e *Ethereum) Start() error {
 // Stop implements node.Lifecycle, terminating all internal goroutines used by the
 // Ethereum protocol.
 func (e *Ethereum) Stop() error {
+	log.Info("Stopping Ethereum bloomIndexer start")
 	e.bloomIndexer.Close()
+	log.Info("Ethereum bloomIndexer stopped")
+
+	log.Info("Stopping Ethereum blockchain start")
 	e.blockchain.Stop()
+	log.Info("Ethereum blockchain stopped")
+
+	log.Info("Stopping Ethereum protocolManager start")
 	e.protocolManager.Stop()
+	log.Info("Ethereum protocolManager stopped")
 
+	log.Info("Stopping Ethereum txPool start")
 	e.txPool.Close()
-	e.miner.Stop()
-	e.eventMux.Stop()
+	log.Info("Ethereum txPool stopped")
 
-	e.chainDb.Close()
+	log.Info("Stopping Ethereum shutdownChan start")
 	close(e.shutdownChan)
+	log.Info("Ethereum shutdownChan stopped")
+
+	log.Info("Stopping Ethereum miner start")
+	e.miner.Stop()
+	log.Info("Ethereum miner stopped")
+
+	log.Info("Stopping Ethereum eventMux start")
+	e.eventMux.Stop()
+	log.Info("Ethereum eventMux stopped")
+
+	log.Info("Stopping Ethereum chainDb start")
+	e.chainDb.Close()
+	log.Info("Ethereum chainDb stopped")
 
 	return nil
 }


### PR DESCRIPTION
# Proposed changes

Close the ethereum shutdown channel before closing the chain database so bloom handler goroutines can exit first. Add stop-step logs around the shutdown path to pinpoint hangs during node exit.

some log messages about abnormal exit:

```text
INFO [04-06|09:42:40.902] Got interrupt, shutting down...
INFO [04-06|09:42:40.911] HTTP server stopped                      endpoint=[::]:8646
INFO [04-06|09:42:40.914] HTTP server stopped                      endpoint=[::]:9646
INFO [04-06|09:42:40.919] IPC endpoint closed                      url=/home/me/xdc_chain/mainnet_2/XDC.ipc
INFO [04-06|09:42:40.922] Blockchain manager stopped
INFO [04-06|09:42:40.922] Stopping Ethereum protocol
WARN [04-06|09:42:40.926] BFT Loop Close
INFO [04-06|09:42:40.940] Ethereum protocol stopped
INFO [04-06|09:42:40.940] Transaction pool stopped
```


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
