### PR TITLE
fix(eth/downloader): avoid blocking completed state sync spindown

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -1503,6 +1503,51 @@ func testFakedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	})
 }
 
+func TestStateSyncSpindownCompletedDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	tester := newTester()
+	defer tester.terminate()
+
+	if err := tester.newPeer("active", 63, testChainBase.shorten(8)); err != nil {
+		t.Fatalf("failed to create peer: %v", err)
+	}
+	peer := tester.downloader.peers.Peer("active")
+	if peer == nil {
+		t.Fatal("peer not registered")
+	}
+	atomic.StoreInt32(&peer.stateIdle, 1)
+	peer.stateStarted = time.Now()
+
+	req := &stateReq{
+		nItems: 1,
+		peer:   peer,
+		timer:  time.NewTimer(time.Hour),
+	}
+	defer req.timer.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		tester.downloader.spindownStateSync(
+			map[string]*stateReq{peer.id: req},
+			nil,
+			make(chan *stateReq),
+			make(chan *peerConnection),
+			true,
+		)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("state sync spindown blocked after completion")
+	}
+	if atomic.LoadInt32(&peer.stateIdle) != 0 {
+		t.Fatal("peer was not marked idle after completed state sync")
+	}
+}
+
 // This test reproduces an issue where unexpected deliveries would
 // block indefinitely if they arrived at the right time.
 func TestDeliverHeadersHang(t *testing.T) {

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -124,11 +124,11 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 		select {
 		// The stateSync lifecycle:
 		case next := <-d.stateSyncStart:
-			d.spindownStateSync(active, finished, timeout, peerDrop)
+			d.spindownStateSync(active, finished, timeout, peerDrop, false)
 			return next
 
 		case <-s.done:
-			d.spindownStateSync(active, finished, timeout, peerDrop)
+			d.spindownStateSync(active, finished, timeout, peerDrop, true)
 			return nil
 
 		// Send the next finished request to the current sync:
@@ -212,8 +212,18 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 // spindownStateSync 'drains' the outstanding requests; some will be delivered and other
 // will time out. This is to ensure that when the next stateSync starts working, all peers
 // are marked as idle and de facto _are_ idle.
-func (d *Downloader) spindownStateSync(active map[string]*stateReq, finished []*stateReq, timeout chan *stateReq, peerDrop chan *peerConnection) {
+func (d *Downloader) spindownStateSync(active map[string]*stateReq, finished []*stateReq, timeout chan *stateReq, peerDrop chan *peerConnection, completed bool) {
 	log.Trace("State sync spinning down", "active", len(active), "finished", len(finished))
+	if completed {
+		for _, req := range active {
+			req.timer.Stop()
+			req.peer.SetNodeDataIdle(int(req.nItems), time.Now())
+		}
+		for _, req := range finished {
+			req.peer.SetNodeDataIdle(int(req.nItems), time.Now())
+		}
+		return
+	}
 
 	for len(active) > 0 {
 		var (


### PR DESCRIPTION
# Proposed changes

Stop waiting for timeout or delivery events after a state sync has already completed. Add a regression test to ensure completed spindown returns promptly and resets peer idleness.

error messages:

```text
panic: test timed out after 45m0s
	running tests:
		TestFakedSyncProgress63Fast (44m48s)

goroutine 24402 [running]:
testing.(*M).startAlarm.func1()
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:2682 +0x345
created by time.goFunc
	/opt/hostedtoolcache/go/1.25.8/x64/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive, 44 minutes]:
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1891 +0x451
testing.tRunner(0xc000103dc0, 0xc0007dac70)
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1940 +0x123
testing.runTests(0xc005e9ad68, {0x10c9f20, 0x76, 0x76}, {0x7?, 0xc005eb5040?, 0x111c240?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:2475 +0x4b4
testing.(*M).Run(0xc005b42d20)
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:2337 +0x63a
main.main()
	_testmain.go:289 +0x9b

goroutine 7615 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spindownStateSync(0xc003a64ea0, 0xc00dd71e80, {0xc003850998, 0x0, 0x9b7d80?}, 0xc00292ebd0, 0xc00e580700)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/statesync.go:223 +0x26f
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).runStateSync(0xc003a64ea0, 0xc0000e9680)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/statesync.go:131 +0xed2
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).stateFetcher(0xc003a64ea0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/statesync.go:85 +0x154
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.New in goroutine 157
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:247 +0x545

goroutine 7758 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).processHeaders(0xc003a64ea0, 0xfc5c1b772cc7f45f?, 0x3ab, 0xc000694440)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:1338 +0x23a
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncWithPeer.func6()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:484 +0x36
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x70
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync in goroutine 7730
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x9c

goroutine 157 [sync.WaitGroup.Wait, 44 minutes]:
sync.runtime_SemacquireWaitGroup(0xc38cd8?, 0x1?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/runtime/sema.go:114 +0x2e
sync.(*WaitGroup).Wait(0xc0067acab0)
	/opt/hostedtoolcache/go/1.25.8/x64/src/sync/waitgroup.go:206 +0x85
github.com/XinFinOrg/XDPoSChain/eth/downloader.testFakedSyncProgress(0xc008153dc0, 0x3f, 0x1)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader_test.go:1499 +0x495
github.com/XinFinOrg/XDPoSChain/eth/downloader.TestFakedSyncProgress63Fast(0xc008153dc0?)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader_test.go:1434 +0x1d
testing.tRunner(0xc008153dc0, 0xb92e60)
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1997 +0x465

goroutine 7759 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncState(0xc003a64ea0, {0x12, 0x8b, 0xbd, 0xce, 0x5e, 0xcf, 0x8f, 0xf5, 0x4f, ...})
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/statesync.go:65 +0xcf
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).processFastSyncContent(0xc003a64ea0, 0xc00068f408)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:1570 +0xaa
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncWithPeer.func7()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:487 +0x2b
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x70
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync in goroutine 7730
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x9c

goroutine 7756 [select]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).fetchParts(0xc003a64ea0, 0xc0000f6fc0, 0xc001933f08, 0xc006af2f00, 0xc001933ef8, 0xc001933ed0, 0xc001933f48, 0xc001933f38, 0x0, 0xb931d8, ...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:1141 +0x1ed
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).fetchBodies(0xc003a64ea0, 0x2ec)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:1069 +0x2a5
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncWithPeer.func4()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:482 +0x2e
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x70
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync in goroutine 7730
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x9c

goroutine 7614 [select]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).qosTuner(0xc003a64ea0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:1792 +0x3ae
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.New in goroutine 157
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:246 +0x505

goroutine 7755 [select]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).fetchHeaders(0xc003a64ea0, 0xc00ba651d0, 0x2ec, 0x3ab)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:908 +0x12af
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncWithPeer.func3()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:481 +0x36
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x70
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync in goroutine 7730
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x9c

goroutine 7757 [select]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).fetchParts(0xc003a64ea0, 0xc0000f7030, 0xc00060bf08, 0xc006af2f80, 0xc00060bef8, 0xc00060bed0, 0xc00060bf48, 0xc00060bf38, 0x0, 0xb931e8, ...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:1141 +0x1ed
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).fetchReceipts(0xc003a64ea0, 0x2ec)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:1095 +0x2a5
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncWithPeer.func5()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:483 +0x2e
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x70
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync in goroutine 7730
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:500 +0x9c

goroutine 7730 [chan receive, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync(0xc003a64ea0, {0xc00020ae00, 0x5, 0x96d4e98be9c4f27f?})
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:511 +0x1bb
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncWithPeer(0xc003a64ea0, 0xc00ba651d0, {0x2f, 0x76, 0xfa, 0x1b, 0xa, 0x67, 0x1b, 0xa2, ...}, ...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:491 +0x99a
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).synchronise(0xc000805400?, {0xa7eaa1, 0x5}, {0x2f, 0x76, 0xfa, 0x1b, 0xa, 0x67, 0x1b, ...}, ...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader.go:411 +0x4d6
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*downloadTester).sync(0xc0000e92c0, {0xa7eaa1, 0x5}, 0x0, 0x1)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader_test.go:108 +0x1c5
github.com/XinFinOrg/XDPoSChain/eth/downloader.testFakedSyncProgress.func3()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader_test.go:1487 +0x5c
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.testFakedSyncProgress in goroutine 157
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/eth/downloader/downloader_test.go:1485 +0x425
FAIL	github.com/XinFinOrg/XDPoSChain/eth/downloader	2700.829s
```


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
