### PR TITLE
fix(core,eth/tracers): resolve coinbase owner per transaction

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -99,7 +99,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, tra
 	context := NewEVMBlockContext(header, p.bc, nil)
 	evm := vm.NewEVM(context, tracingStateDB, tradingState, p.config, cfg)
 	signer := types.MakeSigner(p.config, blockNumber)
-	coinbaseOwner := getCoinbaseOwner(p.bc, statedb, header, nil)
 
 	if p.config.IsPrague(block.Number()) {
 		ProcessParentBlockHash(block.ParentHash(), evm)
@@ -145,7 +144,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, tra
 		}
 		statedb.SetTxContext(tx.Hash(), i)
 
-		receipt, gas, tokenFeeUsed, err := ApplyTransactionWithEVM(msg, gp, statedb, blockNumber, blockHash, tx, usedGas, evm, balanceFee, coinbaseOwner)
+		receipt, gas, tokenFeeUsed, err := ApplyTransactionWithEVM(msg, gp, statedb, blockNumber, blockHash, tx, usedGas, evm, balanceFee)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
@@ -206,7 +205,6 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 	context := NewEVMBlockContext(header, p.bc, nil)
 	evm := vm.NewEVM(context, tracingStateDB, tradingState, p.config, cfg)
 	signer := types.MakeSigner(p.config, blockNumber)
-	coinbaseOwner := getCoinbaseOwner(p.bc, statedb, header, nil)
 
 	if p.config.IsPrague(block.Number()) {
 		ProcessParentBlockHash(block.ParentHash(), evm)
@@ -252,7 +250,7 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 		}
 		statedb.SetTxContext(tx.Hash(), i)
 
-		receipt, gas, tokenFeeUsed, err := ApplyTransactionWithEVM(msg, gp, statedb, blockNumber, blockHash, tx, usedGas, evm, balanceFee, coinbaseOwner)
+		receipt, gas, tokenFeeUsed, err := ApplyTransactionWithEVM(msg, gp, statedb, blockNumber, blockHash, tx, usedGas, evm, balanceFee)
 		if err != nil {
 			return nil, nil, 0, err
 		}
@@ -278,7 +276,7 @@ func (p *StateProcessor) ProcessBlockNoValidator(cBlock *CalculatedBlock, stated
 // ApplyTransactionWithEVM attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment similar to ApplyTransaction. However,
 // this method takes an already created EVM instance as input.
-func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, balanceFee *big.Int, coinbaseOwner common.Address) (receipt *types.Receipt, gasUsed uint64, tokenFeeUsed bool, err error) {
+func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, balanceFee *big.Int) (receipt *types.Receipt, gasUsed uint64, tokenFeeUsed bool, err error) {
 	if hooks := evm.Config.Tracer; hooks != nil {
 		if hooks.OnTxStart != nil {
 			hooks.OnTxStart(evm.GetVMContext(), tx, msg.From)
@@ -315,6 +313,7 @@ func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, 
 	applyHistoricalBalanceBypass(statedb, blockNumber, msg.From)
 
 	// Apply the transaction to the current state (included in the env)
+	coinbaseOwner := statedb.GetOwner(evm.Context.Coinbase)
 	result, err := ApplyMessage(evm, msg, gp, coinbaseOwner)
 	if err != nil {
 		return nil, 0, false, err
@@ -363,17 +362,6 @@ func MakeReceipt(evm *vm.EVM, result *ExecutionResult, statedb *state.StateDB, b
 	return receipt
 }
 
-func getCoinbaseOwner(bc *BlockChain, statedb *state.StateDB, header *types.Header, author *common.Address) common.Address {
-	// If we don't have an explicit author (i.e. not mining), extract from the header
-	var beneficiary common.Address
-	if author == nil {
-		beneficiary, _ = bc.Engine().Author(header) // Ignore error, we're past header validation
-	} else {
-		beneficiary = *author
-	}
-	return statedb.GetOwner(beneficiary)
-}
-
 // ApplyTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
@@ -391,8 +379,7 @@ func ApplyTransaction(tokensFee map[common.Address]*big.Int, evm *vm.EVM, gp *Ga
 	if err != nil {
 		return nil, 0, false, err
 	}
-	coinbaseOwner := statedb.GetOwner(evm.Context.Coinbase)
-	return ApplyTransactionWithEVM(msg, gp, statedb, header.Number, header.Hash(), tx, usedGas, evm, balanceFee, coinbaseOwner)
+	return ApplyTransactionWithEVM(msg, gp, statedb, header.Number, header.Hash(), tx, usedGas, evm, balanceFee)
 }
 
 func ApplySignTransaction(msg *Message, config *params.ChainConfig, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (receipt *types.Receipt, gasUsed uint64, tokenFeeUsed bool, err error) {

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -499,7 +499,7 @@ func TestApplyTransactionWithEVMTracer(t *testing.T) {
 
 			// Apply transaction
 			var usedGas uint64
-			_, _, _, err = ApplyTransactionWithEVM(msg, gasPool, statedb, blockNumber, blockHash, signedTx, &usedGas, evm, big.NewInt(0), common.Address{})
+			_, _, _, err = ApplyTransactionWithEVM(msg, gasPool, statedb, blockNumber, blockHash, signedTx, &usedGas, evm, big.NewInt(0))
 			// NOTE: Some special transactions (like BlockSignersBinary or XDCXAddrBinary)
 			// may fail in test environment due to missing configuration or state, but
 			// the tracer should still be called at the beginning of ApplyTransactionWithEVM.
@@ -587,7 +587,7 @@ func TestApplyTransactionWithEVMStateChangeHooks(t *testing.T) {
 
 	gasPool := new(GasPool).AddGas(1000000)
 	var usedGas uint64
-	_, _, _, err = ApplyTransactionWithEVM(msg, gasPool, statedb, big.NewInt(1), genesis.Hash(), signedTx, &usedGas, evmenv, nil, common.Address{})
+	_, _, _, err = ApplyTransactionWithEVM(msg, gasPool, statedb, big.NewInt(1), genesis.Hash(), signedTx, &usedGas, evmenv, nil)
 	if err != nil {
 		t.Fatalf("ApplyTransactionWithEVM failed: %v", err)
 	}
@@ -647,7 +647,7 @@ func TestApplyTransactionWithEVMRejectsValueOverflow(t *testing.T) {
 	evmenv := vm.NewEVM(vmContext, statedb, nil, blockchain.Config(), vm.Config{})
 	gasPool := new(GasPool).AddGas(1000000)
 	var usedGas uint64
-	_, _, _, err = ApplyTransactionWithEVM(msg, gasPool, statedb, big.NewInt(1), genesis.Hash(), signedTx, &usedGas, evmenv, nil, common.Address{})
+	_, _, _, err = ApplyTransactionWithEVM(msg, gasPool, statedb, big.NewInt(1), genesis.Hash(), signedTx, &usedGas, evmenv, nil)
 	if !errors.Is(err, types.ErrUint256Overflow) {
 		t.Fatalf("expected %v, got %v", types.ErrUint256Overflow, err)
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -931,7 +931,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 
 	// Call SetTxContext to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	_, _, _, err = core.ApplyTransactionWithEVM(message, new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, evm, balance, common.Address{})
+	_, _, _, err = core.ApplyTransactionWithEVM(message, new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, evm, balance)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}


### PR DESCRIPTION
# Proposed changes

Resolve the coinbase owner inside ApplyTransactionWithEVM instead of passing a precomputed value from block processing.

This keeps fee routing aligned with the active state for each transaction and makes the block execution and tracer paths use the same owner-resolution logic.

Ref: https://github.com/XinFinOrg/XDPoSChain/pull/649

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
