### PR TITLE
fix(core,txpool,ethapi): reject overflowing tx values

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -19,6 +19,7 @@ package core
 import (
 	"crypto/ecdsa"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -595,6 +596,63 @@ func TestApplyTransactionWithEVMStateChangeHooks(t *testing.T) {
 	}
 	if !hookInvoked {
 		t.Fatal("expected OnBalanceChange to be invoked, but it was not")
+	}
+}
+
+func TestApplyTransactionWithEVMRejectsValueOverflow(t *testing.T) {
+	t.Parallel()
+
+	config := &params.ChainConfig{
+		ChainID:        big.NewInt(1),
+		HomesteadBlock: big.NewInt(0),
+		EIP155Block:    big.NewInt(0),
+		EIP158Block:    big.NewInt(0),
+		ByzantiumBlock: big.NewInt(0),
+		Ethash:         new(params.EthashConfig),
+	}
+	signer := types.LatestSigner(config)
+	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	if err != nil {
+		t.Fatalf("Failed to create key: %v", err)
+	}
+	sender := crypto.PubkeyToAddress(key.PublicKey)
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tooBigValue := new(big.Int).Lsh(big.NewInt(1), 256)
+	hugeBalance := new(big.Int).Lsh(big.NewInt(1), 300)
+
+	db := rawdb.NewMemoryDatabase()
+	gspec := &Genesis{
+		Config: config,
+		Alloc: types.GenesisAlloc{
+			sender: {
+				Balance: hugeBalance,
+			},
+		},
+	}
+	genesis := gspec.MustCommit(db)
+	blockchain, _ := NewBlockChain(db, nil, gspec, ethash.NewFaker(), vm.Config{})
+	defer blockchain.Stop()
+
+	statedb, err := blockchain.State()
+	if err != nil {
+		t.Fatalf("Failed to get state: %v", err)
+	}
+	tx := types.NewTransaction(0, recipient, tooBigValue, 21000, big.NewInt(1), nil)
+	signedTx, err := types.SignTx(tx, signer, key)
+	if err != nil {
+		t.Fatalf("Failed to sign tx: %v", err)
+	}
+	msg, err := TransactionToMessage(signedTx, signer, nil, big.NewInt(1), nil)
+	if err != nil {
+		t.Fatalf("Failed to build message: %v", err)
+	}
+	vmContext := NewEVMBlockContext(blockchain.CurrentBlock(), blockchain, nil)
+	evmenv := vm.NewEVM(vmContext, statedb, nil, blockchain.Config(), vm.Config{})
+	gasPool := new(GasPool).AddGas(1000000)
+	var usedGas uint64
+	_, _, _, err = ApplyTransactionWithEVM(msg, gasPool, statedb, big.NewInt(1), genesis.Hash(), signedTx, &usedGas, evmenv, nil, common.Address{})
+	if !errors.Is(err, types.ErrUint256Overflow) {
+		t.Fatalf("expected %v, got %v", types.ErrUint256Overflow, err)
 	}
 }
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -433,7 +433,7 @@ func (st *StateTransition) TransitionDb(owner common.Address) (*ExecutionResult,
 	// Check clause 6
 	value, overflow := uint256.FromBig(msg.Value)
 	if overflow {
-		return nil, fmt.Errorf("%w: address %v", ErrInsufficientFundsForTransfer, msg.From.Hex())
+		return nil, fmt.Errorf("%w: address %v", types.ErrUint256Overflow, msg.From.Hex())
 	}
 	if !value.IsZero() && !st.evm.Context.CanTransfer(st.state, msg.From, value) {
 		return nil, fmt.Errorf("%w: address %v", ErrInsufficientFundsForTransfer, msg.From.Hex())

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -733,6 +733,19 @@ func TestNegativeValue(t *testing.T) {
 	}
 }
 
+func TestValueOverflow(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupPool()
+	defer pool.Close()
+
+	tooBigValue := new(big.Int).Lsh(big.NewInt(1), 256)
+	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, tooBigValue, 100, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	if err := pool.ValidateTxBasics(tx); !errors.Is(err, types.ErrUint256Overflow) {
+		t.Error("expected", types.ErrUint256Overflow, "got", err)
+	}
+}
+
 // TestValidateTransactionEIP2681 tests that the pool correctly validates transactions
 // according to EIP-2681, which limits the nonce to a maximum value of 2^64 - 1.
 func TestValidateTransactionEIP2681(t *testing.T) {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -77,8 +77,12 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur for transactions created using the RPC.
-	if tx.Value().Sign() < 0 {
+	val := tx.Value()
+	if val.Sign() < 0 {
 		return ErrNegativeValue
+	}
+	if val.BitLen() > 256 {
+		return types.ErrUint256Overflow
 	}
 	// Ensure the transaction doesn't exceed the current block limit gas
 	if head.GasLimit < tx.Gas() {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -3180,6 +3180,9 @@ type txPoolBackendMock struct {
 
 func (b *sendTxBackendMock) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	b.lastTx = signedTx
+	if signedTx.Value().BitLen() > 256 {
+		return types.ErrUint256Overflow
+	}
 	if b.sendErr != nil {
 		return b.sendErr
 	}
@@ -3442,6 +3445,43 @@ func TestSendRawTransactionFeeCapExceeded(t *testing.T) {
 
 	_, err = api.SendRawTransaction(context.Background(), raw)
 	require.ErrorContains(t, err, "exceeds the configured cap")
+}
+
+func TestSendRawTransactionRejectsValueOverflow(t *testing.T) {
+	t.Parallel()
+
+	key, err := crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+	require.NoError(t, err)
+
+	backend := &sendTxBackendMock{backendMock: newBackendMock()}
+	api := NewTransactionAPI(backend, nil)
+
+	to := common.Address{0x56}
+	overflowValue := new(big.Int).Lsh(big.NewInt(1), 256)
+	tx, err := types.SignNewTx(key, types.LatestSigner(backend.ChainConfig()), &types.LegacyTx{
+		Nonce:    11,
+		GasPrice: big.NewInt(2),
+		Gas:      21000,
+		To:       &to,
+		Value:    overflowValue,
+	})
+	require.NoError(t, err)
+
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = api.SendRawTransaction(context.Background(), raw)
+	require.ErrorIs(t, err, types.ErrUint256Overflow)
+	require.NotNil(t, backend.lastTx)
+	require.Equal(t, overflowValue, backend.lastTx.Value())
+}
+
+func TestTxValidationErrorUint256Overflow(t *testing.T) {
+	t.Parallel()
+
+	err := txValidationError(types.ErrUint256Overflow)
+	require.Equal(t, errCodeInvalidParams, err.ErrorCode())
+	require.ErrorContains(t, err, types.ErrUint256Overflow.Error())
 }
 
 func TestGetTransactionByHashBasic(t *testing.T) {

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -23,6 +23,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi"
 	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
 	"github.com/XinFinOrg/XDPoSChain/core"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 )
 
@@ -106,6 +107,8 @@ func txValidationError(err error) *invalidTxError {
 	case errors.Is(err, core.ErrTipAboveFeeCap):
 		return &invalidTxError{Message: err.Error(), Code: errCodeInvalidParams}
 	case errors.Is(err, core.ErrFeeCapTooLow):
+		return &invalidTxError{Message: err.Error(), Code: errCodeInvalidParams}
+	case errors.Is(err, types.ErrUint256Overflow):
 		return &invalidTxError{Message: err.Error(), Code: errCodeInvalidParams}
 	case errors.Is(err, core.ErrInsufficientFunds):
 		return &invalidTxError{Message: err.Error(), Code: errCodeInsufficientFunds}


### PR DESCRIPTION
# Proposed changes

Reject transaction values above uint256 max during txpool validation and execution.

Map the overflow to an invalid params RPC error and add focused unit tests.

fix #2287 

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
