### PR TITLE
fix(core/vm): remove EIP-7702 extcode overrides #31089

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -18,11 +18,8 @@ package vm
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
-	"github.com/XinFinOrg/XDPoSChain/core/types"
-	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/holiman/uint256"
 )
@@ -354,65 +351,8 @@ func enable8024(jt *JumpTable) {
 	}
 }
 
-// opExtCodeCopyEIP7702 implements the EIP-7702 variation of opExtCodeCopy.
-func opExtCodeCopyEIP7702(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
-	var (
-		stack      = scope.Stack
-		a          = stack.pop()
-		memOffset  = stack.pop()
-		codeOffset = stack.pop()
-		length     = stack.pop()
-	)
-	uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
-	if overflow {
-		uint64CodeOffset = math.MaxUint64
-	}
-	code := evm.StateDB.GetCode(common.Address(a.Bytes20()))
-	if _, ok := types.ParseDelegation(code); ok {
-		code = types.DelegationPrefix[:2]
-	}
-	codeCopy := getData(code, uint64CodeOffset, length.Uint64())
-	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
-
-	return nil, nil
-}
-
-// opExtCodeSizeEIP7702 implements the EIP-7702 variation of opExtCodeSize.
-func opExtCodeSizeEIP7702(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
-	slot := scope.Stack.peek()
-	code := evm.StateDB.GetCode(common.Address(slot.Bytes20()))
-	if _, ok := types.ParseDelegation(code); ok {
-		code = types.DelegationPrefix[:2]
-	}
-	slot.SetUint64(uint64(len(code)))
-	return nil, nil
-}
-
-// opExtCodeHashEIP7702 implements the EIP-7702 variation of opExtCodeHash.
-func opExtCodeHashEIP7702(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
-	slot := scope.Stack.peek()
-	addr := common.Address(slot.Bytes20())
-	if evm.StateDB.Empty(addr) {
-		slot.Clear()
-		return nil, nil
-	}
-	code := evm.StateDB.GetCode(addr)
-	if _, ok := types.ParseDelegation(code); ok {
-		// If the code is a delegation, return the prefix without version.
-		slot.SetBytes(crypto.Keccak256(types.DelegationPrefix[:2]))
-	} else {
-		// Otherwise, return normal code hash.
-		slot.SetBytes(evm.StateDB.GetCodeHash(addr).Bytes())
-	}
-	return nil, nil
-}
-
 // enable7702 enables the EIP-7702 changes to support delegation designators.
 func enable7702(jt *JumpTable) {
-	jt[EXTCODECOPY].execute = opExtCodeCopyEIP7702
-	jt[EXTCODESIZE].execute = opExtCodeSizeEIP7702
-	jt[EXTCODEHASH].execute = opExtCodeHashEIP7702
-
 	jt[CALL].dynamicGas = gasCallEIP7702
 	jt[CALLCODE].dynamicGas = gasCallCodeEIP7702
 	jt[STATICCALL].dynamicGas = gasStaticCallEIP7702

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -17,6 +17,7 @@
 package runtime
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math/big"
@@ -36,6 +37,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/core/vm/program"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/eth/tracers"
 	"github.com/XinFinOrg/XDPoSChain/eth/tracers/logger"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -951,5 +953,63 @@ func TestDelegatedAccountAccessCost(t *testing.T) {
 		if want := tc.want; have != want {
 			t.Fatalf("testcase %d, gas report wrong, step %d, have %d want %d", i, tc.step, have, want)
 		}
+	}
+}
+
+func TestDelegatedAccountExtCodeOpcodes(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+
+	delegated := common.HexToAddress("0xff")
+	target := common.HexToAddress("0xaa")
+	delegationCode := types.AddressToDelegation(target)
+	targetCode := []byte{0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3}
+
+	statedb.SetCode(delegated, delegationCode)
+	statedb.SetCode(target, targetCode)
+
+	for _, tc := range []struct {
+		name string
+		code []byte
+		want []byte
+	}{
+		{
+			name: "extcodesize returns delegation size",
+			code: program.New().
+				Push(delegated).Op(vm.EXTCODESIZE).
+				Push(0).Op(vm.MSTORE).
+				Return(0, 32).
+				Bytes(),
+			want: common.LeftPadBytes(new(big.Int).SetUint64(uint64(len(delegationCode))).Bytes(), 32),
+		},
+		{
+			name: "extcodehash returns delegation hash",
+			code: program.New().
+				Push(delegated).Op(vm.EXTCODEHASH).
+				Push(0).Op(vm.MSTORE).
+				Return(0, 32).
+				Bytes(),
+			want: crypto.Keccak256(delegationCode),
+		},
+		{
+			name: "extcodecopy returns delegation bytes",
+			code: program.New().
+				ExtcodeCopy(delegated, 0, 0, len(delegationCode)).
+				Return(0, len(delegationCode)).
+				Bytes(),
+			want: delegationCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			have, _, err := Execute(tc.code, nil, &Config{
+				ChainConfig: params.MergedTestChainConfig,
+				State:       statedb.Copy(),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(have, tc.want) {
+				t.Fatalf("wrong return data, have %x want %x", have, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

Remove the custom EIP-7702 handlers for EXTCODECOPY, EXTCODESIZE, and EXTCODEHASH so the jump table keeps the default opcode behavior. This also drops the now-unused imports tied to delegation-specific code paths.

Ref: #31089


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
