### PR TITLE
feat(core): state journal wrapper #30441 #33978

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -113,7 +113,7 @@ func hashAlloc(ga *types.GenesisAlloc) (common.Hash, error) {
 			statedb.AddBalance(addr, account.Balance, tracing.BalanceIncreaseGenesisBalance)
 		}
 		statedb.SetCode(addr, account.Code)
-		statedb.SetNonce(addr, account.Nonce)
+		statedb.SetNonce(addr, account.Nonce, tracing.NonceChangeGenesis)
 		for key, value := range account.Storage {
 			statedb.SetState(addr, key, value)
 		}
@@ -134,7 +134,7 @@ func flushAlloc(ga *types.GenesisAlloc, db ethdb.Database, blockhash common.Hash
 			statedb.AddBalance(addr, account.Balance, tracing.BalanceIncreaseGenesisBalance)
 		}
 		statedb.SetCode(addr, account.Code)
-		statedb.SetNonce(addr, account.Nonce)
+		statedb.SetNonce(addr, account.Nonce, tracing.NonceChangeGenesis)
 		for key, value := range account.Storage {
 			statedb.SetState(addr, key, value)
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -450,7 +450,7 @@ func (s *StateDB) SetBalance(addr common.Address, amount *big.Int, _ tracing.Bal
 	}
 }
 
-func (s *StateDB) SetNonce(addr common.Address, nonce uint64) {
+func (s *StateDB) SetNonce(addr common.Address, nonce uint64, _ tracing.NonceChangeReason) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetNonce(nonce)

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -67,7 +67,7 @@ func newStateTestAction(addr common.Address, r *rand.Rand, index int) testAction
 		{
 			name: "SetNonce",
 			fn: func(a testAction, s *StateDB) {
-				s.SetNonce(addr, uint64(a.args[0]))
+				s.SetNonce(addr, uint64(a.args[0]), tracing.NonceChangeUnspecified)
 			},
 			args: make([]int64, 1),
 		},

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -166,10 +166,12 @@ func (s *hookedStateDB) AddBalance(addr common.Address, amount *big.Int, reason 
 	return prev
 }
 
-func (s *hookedStateDB) SetNonce(address common.Address, nonce uint64) {
+func (s *hookedStateDB) SetNonce(address common.Address, nonce uint64, reason tracing.NonceChangeReason) {
 	prev := s.inner.GetNonce(address)
-	s.inner.SetNonce(address, nonce)
-	if s.hooks.OnNonceChange != nil {
+	s.inner.SetNonce(address, nonce, reason)
+	if s.hooks.OnNonceChangeV2 != nil {
+		s.hooks.OnNonceChangeV2(address, prev, nonce, reason)
+	} else if s.hooks.OnNonceChange != nil {
 		s.hooks.OnNonceChange(address, prev, nonce)
 	}
 }

--- a/core/state/statedb_hooked_test.go
+++ b/core/state/statedb_hooked_test.go
@@ -112,7 +112,7 @@ func TestHooks(t *testing.T) {
 	})
 	sdb.AddBalance(common.Address{0xaa}, big.NewInt(100), tracing.BalanceChangeUnspecified)
 	sdb.SubBalance(common.Address{0xaa}, big.NewInt(50), tracing.BalanceChangeTransfer)
-	sdb.SetNonce(common.Address{0xaa}, 1337)
+	sdb.SetNonce(common.Address{0xaa}, 1337, tracing.NonceChangeGenesis)
 	sdb.SetCode(common.Address{0xaa}, []byte{0x13, 37})
 	sdb.SetState(common.Address{0xaa}, common.HexToHash("0x01"), common.HexToHash("0x11"))
 	sdb.SetState(common.Address{0xaa}, common.HexToHash("0x01"), common.HexToHash("0x22"))

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -46,7 +46,7 @@ func TestUpdateLeaks(t *testing.T) {
 	for i := byte(0); i < 255; i++ {
 		addr := common.BytesToAddress([]byte{i})
 		state.AddBalance(addr, big.NewInt(int64(11*i)), tracing.BalanceChangeUnspecified)
-		state.SetNonce(addr, uint64(42*i))
+		state.SetNonce(addr, uint64(42*i), tracing.NonceChangeUnspecified)
 		if i%2 == 0 {
 			state.SetState(addr, common.BytesToHash([]byte{i, i, i}), common.BytesToHash([]byte{i, i, i, i}))
 		}
@@ -79,7 +79,7 @@ func TestIntermediateLeaks(t *testing.T) {
 
 	modify := func(state *StateDB, addr common.Address, i, tweak byte) {
 		state.SetBalance(addr, big.NewInt(int64(11*i)+int64(tweak)), tracing.BalanceChangeUnspecified)
-		state.SetNonce(addr, uint64(42*i+tweak))
+		state.SetNonce(addr, uint64(42*i+tweak), tracing.NonceChangeUnspecified)
 		if i%2 == 0 {
 			state.SetState(addr, common.Hash{i, i, i, 0}, common.Hash{})
 			state.SetState(addr, common.Hash{i, i, i, tweak}, common.Hash{i, i, i, i, tweak})
@@ -336,7 +336,7 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 		{
 			name: "SetNonce",
 			fn: func(a testAction, s *StateDB) {
-				s.SetNonce(addr, uint64(a.args[0]))
+				s.SetNonce(addr, uint64(a.args[0]), tracing.NonceChangeUnspecified)
 			},
 			args: make([]int64, 1),
 		},

--- a/core/state/statedb_utils.go
+++ b/core/state/statedb_utils.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/tracing"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 )
@@ -154,7 +155,7 @@ func (s *StateDB) GetVoterCap(candidate, voter common.Address) *big.Int {
 
 func (s *StateDB) IncrementMintedRecordNonce() {
 	nonce := s.GetNonce(common.MintedRecordAddressBinary)
-	s.SetNonce(common.MintedRecordAddressBinary, nonce+1)
+	s.SetNonce(common.MintedRecordAddressBinary, nonce+1, tracing.NonceChangeUnspecified)
 }
 
 var (

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -570,7 +570,7 @@ func ApplySignTransaction(msg *Message, config *params.ChainConfig, statedb *sta
 			return nil, 0, false, ErrNonceTooLow
 		}
 		// Only increment the nonce for real transactions.
-		statedb.SetNonce(from, nonce+1)
+		statedb.SetNonce(from, nonce+1, tracing.NonceChangeEoACall)
 	}
 	// Create a new receipt for the transaction, storing the intermediate root and gas used by the tx
 	// based on the eip phase, we're passing whether the root touch-delete accounts.
@@ -675,7 +675,7 @@ func ProcessParentBlockHash(prevHash common.Hash, evm *vm.EVM) {
 			evm.StateDB.CreateAccount(params.HistoryStorageAddress)
 		}
 		if evm.StateDB.GetNonce(params.HistoryStorageAddress) == 0 {
-			evm.StateDB.SetNonce(params.HistoryStorageAddress, 1)
+			evm.StateDB.SetNonce(params.HistoryStorageAddress, 1, tracing.NonceChangeUnspecified)
 		}
 		evm.StateDB.SetCode(params.HistoryStorageAddress, params.HistoryStorageCode)
 

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -608,7 +608,7 @@ func TestProcessParentBlockHash(t *testing.T) {
 		coinbase    = common.Address{}
 	)
 	test := func(statedb *state.StateDB) {
-		statedb.SetNonce(params.HistoryStorageAddress, 1)
+		statedb.SetNonce(params.HistoryStorageAddress, 1, tracing.NonceChangeUnspecified)
 		statedb.SetCode(params.HistoryStorageAddress, params.HistoryStorageCode)
 		statedb.IntermediateRoot(true)
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -459,7 +459,7 @@ func (st *StateTransition) TransitionDb(owner common.Address) (*ExecutionResult,
 		ret, _, st.gasRemaining, vmerr = st.evm.Create(msg.From, msg.Data, st.gasRemaining, value)
 	} else {
 		// Increment the nonce for the next transaction
-		st.state.SetNonce(msg.From, st.state.GetNonce(msg.From)+1)
+		st.state.SetNonce(msg.From, st.state.GetNonce(msg.From)+1, tracing.NonceChangeEoACall)
 
 		// Apply EIP-7702 authorizations.
 		if msg.SetCodeAuthorizations != nil {
@@ -567,7 +567,7 @@ func (st *StateTransition) applyAuthorization(msg *Message, auth *types.SetCodeA
 	}
 
 	// Update nonce and account code.
-	st.state.SetNonce(authority, auth.Nonce+1)
+	st.state.SetNonce(authority, auth.Nonce+1, tracing.NonceChangeAuthorization)
 	if auth.Address == (common.Address{}) {
 		// Delegation to zero address means clear.
 		st.state.SetCode(authority, nil)

--- a/core/tracing/CHANGELOG.md
+++ b/core/tracing/CHANGELOG.md
@@ -2,7 +2,59 @@
 
 All notable changes to the tracing interface will be documented in this file.
 
-## [Unreleased]
+## Unreleased
+
+## [v1.15.0](https://github.com/ethereum/go-ethereum/releases/tag/v1.15.0)
+
+The tracing interface has been extended with backwards-compatible changes to support more use-cases and simplify tracer code. The most notable change is a state journaling library which emits reverse events when a call is reverted.
+
+### Deprecated methods
+
+- `OnSystemCallStart()`: This hook is deprecated in favor of `OnSystemCallStartV2(vm *VMContext)`.
+- `OnNonceChange(addr common.Address, prev, new uint64)`: This hook is deprecated in favor of `OnNonceChangeV2(addr common.Address, prev, new uint64, reason NonceChangeReason)`.
+
+### Added methods
+
+- `OnBlockHashRead(blockNum uint64, hash common.Hash)`: This hook is called when a block hash is read by EVM.
+- `OnSystemCallStartV2(vm *VMContext)`: This allows access to EVM context during system calls. It is a successor to `OnSystemCallStart`.
+- `OnNonceChangeV2(addr common.Address, prev, new uint64, reason NonceChangeReason)`: This hook is called when a nonce change occurs. It is a successor to `OnNonceChange`.
+
+### New types
+
+- `NonceChangeReason` is a new type used to provide a reason for nonce changes. Notably it includes `NonceChangeRevert` which will be emitted by the state journaling library when a nonce change is due to a revert.
+
+### Modified types
+
+- `VMContext.StateDB` has been extended with the following method:
+  - `GetCodeHash(addr common.Address) common.Hash` method used to retrieve the code hash of an account.
+- `BalanceChangeReason` has been extended with the `BalanceChangeRevert` reason. More on that below.
+- `GasChangeReason` has been extended with the following reason:
+  - `GasChangeTxDataFloor` is the amount of extra gas the transaction has to pay to reach the minimum gas requirement for the transaction data. This change will always be a negative change.
+
+### State journaling
+
+Tracers receive state changes events from the node. The tracer was so far expected to keep track of modified accounts and slots and revert those changes when a call frame failed. Now a utility tracer wrapper is provided which will emit "reverse change" events when a call frame fails. To use this feature the hooks have to be wrapped prior to registering the tracer. The following example demonstrates how to use the state journaling library:
+
+```go
+func init() {
+    tracers.LiveDirectory.Register("test", func(cfg json.RawMessage) (*tracing.Hooks, error) {
+        hooks, err := newTestTracer(cfg)
+        if err != nil {
+            return nil, err
+        }
+        return tracing.WrapWithJournal(hooks)
+    })
+}
+```
+
+The state changes that are covered by the journaling library are:
+
+- `OnBalanceChange`. Note that `OnBalanceChange` will carry the `BalanceChangeRevert` reason.
+- `OnNonceChange`, `OnNonceChangeV2`
+- `OnCodeChange`
+- `OnStorageChange`
+
+## [v1.14.3](https://github.com/ethereum/go-ethereum/releases/tag/v1.14.3)
 
 There have been minor backwards-compatible changes to the tracing interface to explicitly mark the execution of **system** contracts. As of now the only system call updates the parent beacon block root as per [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788). Other system calls are being considered for the future hardfork.
 
@@ -11,21 +63,20 @@ There have been minor backwards-compatible changes to the tracing interface to e
 - `OnSystemCallStart()`: This hook is called when EVM starts processing a system call. Note system calls happen outside the scope of a transaction. This event will be followed by normal EVM execution events.
 - `OnSystemCallEnd()`: This hook is called when EVM finishes processing a system call.
 
-## [v1.14.0]
+## [v1.14.0](https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0)
 
 There has been a major breaking change in the tracing interface for custom native tracers. JS and built-in tracers are not affected by this change and tracing API methods may be used as before. This overhaul has been done as part of the new live tracing feature ([#29189](https://github.com/ethereum/go-ethereum/pull/29189)). To learn more about live tracing please refer to the [docs](https://geth.ethereum.org/docs/developers/evm-tracing/live-tracing).
 
 **The `EVMLogger` interface which the tracers implemented has been removed.** It has been replaced by a new struct `tracing.Hooks`. `Hooks` keeps pointers to event listening functions. Internally the EVM will use these function pointers to emit events and can skip an event if the tracer has opted not to implement it. In fact this is the main reason for this change of approach. Another benefit is the ease of adding new hooks in future, and dynamically assigning event receivers.
 
-The consequence of this change can be seen in the constructor of a tracer. Let's take the 4byte tracer as an example. Previously the constructor return an instance which satisfied the interface. Now it should return a pointer to `tracers.Tracer` (which is now also a struct as opposed to an interface) and explicitly assign the event listeners. As a side-benefit the tracers will not have to provide empty implementation of methods just to satisfy the interface:
+The consequence of this change can be seen in the constructor of a tracer. Let's take the 4byte tracer as an example. Previously the constructor returned an instance which satisfied the interface. Now it should return a pointer to `tracers.Tracer` (which is now also a struct as opposed to an interface) and explicitly assign the event listeners. As a side-benefit the tracers will not have to provide empty implementations of methods just to satisfy the interface:
 
 ```go
 func newFourByteTracer(ctx *tracers.Context, _ json.RawMessage) (tracers.Tracer, error) {
- t := &fourByteTracer{
-  ids: make(map[string]int),
- }
- return t, nil
-
+    t := &fourByteTracer{
+        ids: make(map[string]int),
+    }
+    return t, nil
 }
 ```
 
@@ -33,17 +84,17 @@ And now:
 
 ```go
 func newFourByteTracer(ctx *tracers.Context, _ json.RawMessage) (*tracers.Tracer, error) {
- t := &fourByteTracer{
-  ids: make(map[string]int),
- }
- return &tracers.Tracer{
-  Hooks: &tracing.Hooks{
-   OnTxStart: t.onTxStart,
-   OnEnter:   t.onEnter,
-  },
-  GetResult: t.getResult,
-  Stop:      t.stop,
- }, nil
+    t := &fourByteTracer{
+        ids: make(map[string]int),
+    }
+    return &tracers.Tracer{
+        Hooks: &tracing.Hooks{
+            OnTxStart: t.onTxStart,
+            OnEnter:   t.onEnter,
+        },
+        GetResult: t.getResult,
+        Stop:      t.stop,
+    }, nil
 }
 ```
 
@@ -51,7 +102,7 @@ func newFourByteTracer(ctx *tracers.Context, _ json.RawMessage) (*tracers.Tracer
 
 If you have sharp eyes you might have noticed the new names for `OnTxStart` and `OnEnter`, previously called `CaptureTxStart` and `CaptureEnter`. Indeed there have been various modifications to the signatures of the event listeners. All method names now follow the `On*` pattern instead of `Capture*`. However the modifications are not limited to the names.
 
-#### New methods
+#### Added listener methods
 
 The live tracing feature was half about adding more observability into the state of the blockchain. As such there have been a host of method additions. Please consult the [Hooks](./hooks.go) struct for the full list of methods. Custom tracers which are invoked through the API (as opposed to "live" tracers) can benefit from the following new methods:
 
@@ -60,7 +111,7 @@ The live tracing feature was half about adding more observability into the state
 - `OnNonceChange(addr common.Address, prev, new uint64)`: This hook tracks the nonce changes of accounts.
 - `OnCodeChange(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte)`: This hook tracks the code changes of accounts.
 - `OnStorageChange(addr common.Address, slot common.Hash, prev, new common.Hash)`: This hook tracks the storage changes of accounts.
-- `OnLogChange(log *types.Log)`: This hook tracks the logs emitted by the EVM.
+- `OnLog(log *types.Log)`: This hook tracks the logs emitted by the EVM.
 
 #### Removed methods
 
@@ -70,10 +121,7 @@ The hooks `CaptureStart` and `CaptureEnd` have been removed. These hooks signale
 
 - `CaptureTxStart` -> `OnTxStart(vm *VMContext, tx *types.Transaction, from common.Address)`. It now emits the full transaction object as well as `from` which should be used to get the sender address. The `*VMContext` is a replacement for the `*vm.EVM` object previously passed to `CaptureStart`.
 - `CaptureTxEnd` -> `OnTxEnd(receipt *types.Receipt, err error)`. It now returns the full receipt object.
-- `CaptureEnter` -> `OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int)`. The new `depth int` parameter indicates the call stack depth. It is 0 for the top-level call. Furthermore, the location where `OnEnter` is called in the EVM is now made a soon as a call is started. This means some specific error cases that were not before calling `OnEnter/OnExit` will now do so, leading some transaction to have an extra call traced.
+- `CaptureEnter` -> `OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int)`. The new `depth int` parameter indicates the call stack depth. It is 0 for the top-level call. Furthermore, the location where `OnEnter` is called in the EVM is now made as soon as a call is started. This means some specific error cases that were not before calling `OnEnter/OnExit` will now do so, leading some transactions to have an extra call traced.
 - `CaptureExit` -> `OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool)`. It has the new `depth` parameter, same as `OnEnter`. The new `reverted` parameter indicates whether the call frame was reverted.
 - `CaptureState` -> `OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error)`. `op` is of type `byte` which can be cast to `vm.OpCode` when necessary. A `*vm.ScopeContext` is not passed anymore. It is replaced by `tracing.OpContext` which offers access to the memory, stack and current contract.
 - `CaptureFault` -> `OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error)`. Similar to above.
-
-[unreleased]: https://github.com/ethereum/go-ethereum/compare/v1.14.0...master
-[v1.14.0]: https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0

--- a/core/tracing/gen_balance_change_reason_stringer.go
+++ b/core/tracing/gen_balance_change_reason_stringer.go
@@ -23,11 +23,12 @@ func _() {
 	_ = x[BalanceIncreaseSelfdestruct-12]
 	_ = x[BalanceDecreaseSelfdestruct-13]
 	_ = x[BalanceDecreaseSelfdestructBurn-14]
+	_ = x[BalanceChangeRevert-15]
 }
 
-const _BalanceChangeReason_name = "BalanceChangeUnspecifiedBalanceIncreaseRewardMineUncleBalanceIncreaseRewardMineBlockBalanceIncreaseWithdrawalBalanceIncreaseGenesisBalanceBalanceIncreaseRewardTransactionFeeBalanceDecreaseGasBuyBalanceIncreaseGasReturnBalanceIncreaseDaoContractBalanceDecreaseDaoAccountBalanceChangeTransferBalanceChangeTouchAccountBalanceIncreaseSelfdestructBalanceDecreaseSelfdestructBalanceDecreaseSelfdestructBurn"
+const _BalanceChangeReason_name = "BalanceChangeUnspecifiedBalanceIncreaseRewardMineUncleBalanceIncreaseRewardMineBlockBalanceIncreaseWithdrawalBalanceIncreaseGenesisBalanceBalanceIncreaseRewardTransactionFeeBalanceDecreaseGasBuyBalanceIncreaseGasReturnBalanceIncreaseDaoContractBalanceDecreaseDaoAccountBalanceChangeTransferBalanceChangeTouchAccountBalanceIncreaseSelfdestructBalanceDecreaseSelfdestructBalanceDecreaseSelfdestructBurnBalanceChangeRevert"
 
-var _BalanceChangeReason_index = [...]uint16{0, 24, 54, 84, 109, 138, 173, 194, 218, 244, 269, 290, 315, 342, 369, 400}
+var _BalanceChangeReason_index = [...]uint16{0, 24, 54, 84, 109, 138, 173, 194, 218, 244, 269, 290, 315, 342, 369, 400, 419}
 
 func (i BalanceChangeReason) String() string {
 	if i >= BalanceChangeReason(len(_BalanceChangeReason_index)-1) {

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// Package tracing defines hooks for 'live tracing' of block processing and transaction
+// execution. Here we define the low-level [Hooks] object that carries hooks which are
+// invoked by the go-ethereum core at various points in the state transition.
+//
+// To create a tracer that can be invoked with Geth, you need to register it using
+// [github.com/ethereum/go-ethereum/eth/tracers.LiveDirectory.Register].
+//
+// See https://geth.ethereum.org/docs/developers/evm-tracing/live-tracing for a tutorial.
+
 package tracing
 
 import (
@@ -41,6 +50,7 @@ type OpContext interface {
 type StateDB interface {
 	GetBalance(common.Address) *big.Int
 	GetNonce(common.Address) uint64
+	GetCodeHash(common.Address) common.Hash
 	GetCode(common.Address) []byte
 	GetState(common.Address, common.Hash) common.Hash
 	Exist(common.Address) bool
@@ -163,6 +173,9 @@ type (
 	// NonceChangeHook is called when the nonce of an account changes.
 	NonceChangeHook = func(addr common.Address, prev, new uint64)
 
+	// NonceChangeHookV2 is called when the nonce of an account changes.
+	NonceChangeHookV2 = func(addr common.Address, prev, new uint64, reason NonceChangeReason)
+
 	// CodeChangeHook is called when the code of an account changes.
 	CodeChangeHook = func(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte)
 
@@ -171,6 +184,9 @@ type (
 
 	// LogHook is called when a log is emitted.
 	LogHook = func(log *types.Log)
+
+	// BlockHashReadHook is called when EVM reads the blockhash of a block.
+	BlockHashReadHook = func(blockNumber uint64, hash common.Hash)
 )
 
 type Hooks struct {
@@ -195,9 +211,12 @@ type Hooks struct {
 	// State events
 	OnBalanceChange BalanceChangeHook
 	OnNonceChange   NonceChangeHook
+	OnNonceChangeV2 NonceChangeHookV2
 	OnCodeChange    CodeChangeHook
 	OnStorageChange StorageChangeHook
 	OnLog           LogHook
+	// Block hash read
+	OnBlockHashRead BlockHashReadHook
 }
 
 // BalanceChangeReason is used to indicate the reason for a balance change, useful
@@ -249,6 +268,10 @@ const (
 	// account within the same tx (captured at end of tx).
 	// Note it doesn't account for a self-destruct which appoints itself as recipient.
 	BalanceDecreaseSelfdestructBurn BalanceChangeReason = 14
+
+	// BalanceChangeRevert is emitted when the balance is reverted back to a previous value due to call failure.
+	// It is only emitted when the tracer has opted in to use the journaling wrapper (WrapWithJournal).
+	BalanceChangeRevert BalanceChangeReason = 15
 )
 
 // GasChangeReason is used to indicate the reason for a gas change, useful
@@ -312,4 +335,30 @@ const (
 	// GasChangeIgnored is a special value that can be used to indicate that the gas change should be ignored as
 	// it will be "manually" tracked by a direct emit of the gas change event.
 	GasChangeIgnored GasChangeReason = 0xFF
+)
+
+// NonceChangeReason is used to indicate the reason for a nonce change.
+type NonceChangeReason byte
+
+const (
+	NonceChangeUnspecified NonceChangeReason = 0
+
+	// NonceChangeGenesis is the nonce allocated to accounts at genesis.
+	NonceChangeGenesis NonceChangeReason = 1
+
+	// NonceChangeEoACall is the nonce change due to an EoA call.
+	NonceChangeEoACall NonceChangeReason = 2
+
+	// NonceChangeContractCreator is the nonce change of an account creating a contract.
+	NonceChangeContractCreator NonceChangeReason = 3
+
+	// NonceChangeNewContract is the nonce change of a newly created contract.
+	NonceChangeNewContract NonceChangeReason = 4
+
+	// NonceChangeAuthorization is the nonce change due to a EIP-7702 authorization.
+	NonceChangeAuthorization NonceChangeReason = 5
+
+	// NonceChangeRevert is emitted when the nonce is reverted back to a previous value due to call failure.
+	// It is only emitted when the tracer has opted in to use the journaling wrapper (WrapWithJournal).
+	NonceChangeRevert NonceChangeReason = 6
 )

--- a/core/tracing/journal.go
+++ b/core/tracing/journal.go
@@ -1,0 +1,245 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tracing
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+)
+
+// journal is a state change journal to be wrapped around a tracer.
+// It will emit the state change hooks with reverse values when a call reverts.
+type journal struct {
+	hooks     *Hooks
+	entries   []entry
+	revisions []int
+}
+
+type entry interface {
+	revert(tracer *Hooks)
+}
+
+// WrapWithJournal wraps the given tracer with a journaling layer.
+func WrapWithJournal(hooks *Hooks) (*Hooks, error) {
+	if hooks == nil {
+		return nil, errors.New("wrapping nil tracer")
+	}
+	// No state change to journal, return the wrapped hooks as is
+	if hooks.OnBalanceChange == nil && hooks.OnNonceChange == nil && hooks.OnNonceChangeV2 == nil && hooks.OnCodeChange == nil && hooks.OnStorageChange == nil {
+		return hooks, nil
+	}
+	if hooks.OnNonceChange != nil && hooks.OnNonceChangeV2 != nil {
+		return nil, errors.New("cannot have both OnNonceChange and OnNonceChangeV2")
+	}
+
+	// Create a new Hooks instance and copy all hooks
+	wrapped := *hooks
+
+	// Create journal
+	j := &journal{hooks: hooks}
+	// Scope hooks need to be re-implemented.
+	wrapped.OnTxEnd = j.OnTxEnd
+	wrapped.OnEnter = j.OnEnter
+	wrapped.OnExit = j.OnExit
+	// Wrap state change hooks.
+	if hooks.OnBalanceChange != nil {
+		wrapped.OnBalanceChange = j.OnBalanceChange
+	}
+	if hooks.OnNonceChange != nil || hooks.OnNonceChangeV2 != nil {
+		// Regardless of which hook version is used in the tracer,
+		// the journal will want to capture the nonce change reason.
+		wrapped.OnNonceChangeV2 = j.OnNonceChangeV2
+		// A precaution to ensure EVM doesn't call both hooks.
+		wrapped.OnNonceChange = nil
+	}
+	if hooks.OnCodeChange != nil {
+		wrapped.OnCodeChange = j.OnCodeChange
+	}
+	if hooks.OnStorageChange != nil {
+		wrapped.OnStorageChange = j.OnStorageChange
+	}
+
+	return &wrapped, nil
+}
+
+// reset clears the journal, after this operation the journal can be used anew.
+// It is semantically similar to calling 'NewJournal', but the underlying slices
+// can be reused.
+func (j *journal) reset() {
+	j.entries = j.entries[:0]
+	j.revisions = j.revisions[:0]
+}
+
+// snapshot records a revision and stores it to the revision stack.
+func (j *journal) snapshot() {
+	rev := len(j.entries)
+	j.revisions = append(j.revisions, rev)
+}
+
+// revert reverts all state changes up to the last tracked revision.
+func (j *journal) revert(hooks *Hooks) {
+	// Replay the journal entries above the last revision to undo changes,
+	// then remove the reverted changes from the journal.
+	rev := j.revisions[len(j.revisions)-1]
+	for i := len(j.entries) - 1; i >= rev; i-- {
+		j.entries[i].revert(hooks)
+	}
+	j.entries = j.entries[:rev]
+	j.popRevision()
+}
+
+// popRevision removes an item from the revision stack. This basically forgets about
+// the last call to snapshot() and moves to the one prior.
+func (j *journal) popRevision() {
+	j.revisions = j.revisions[:len(j.revisions)-1]
+}
+
+// OnTxEnd resets the journal since each transaction has its own EVM call stack.
+func (j *journal) OnTxEnd(receipt *types.Receipt, err error) {
+	j.reset()
+	if j.hooks.OnTxEnd != nil {
+		j.hooks.OnTxEnd(receipt, err)
+	}
+}
+
+// OnEnter is invoked for each EVM call frame and records a journal revision.
+func (j *journal) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	j.snapshot()
+	if j.hooks.OnEnter != nil {
+		j.hooks.OnEnter(depth, typ, from, to, input, gas, value)
+	}
+}
+
+// OnExit is invoked when an EVM call frame ends.
+// If the call has reverted, all state changes made by that frame are undone.
+// If the call did not revert, we forget about changes in that revision.
+func (j *journal) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+	if reverted {
+		j.revert(j.hooks)
+	} else {
+		j.popRevision()
+	}
+	if j.hooks.OnExit != nil {
+		j.hooks.OnExit(depth, output, gasUsed, err, reverted)
+	}
+}
+
+func (j *journal) OnBalanceChange(addr common.Address, prev, new *big.Int, reason BalanceChangeReason) {
+	j.entries = append(j.entries, balanceChange{addr: addr, prev: prev, new: new})
+	if j.hooks.OnBalanceChange != nil {
+		j.hooks.OnBalanceChange(addr, prev, new, reason)
+	}
+}
+
+func (j *journal) OnNonceChangeV2(addr common.Address, prev, new uint64, reason NonceChangeReason) {
+	j.entries = append(j.entries, nonceChange{addr: addr, prev: prev, new: new})
+	if reason == NonceChangeContractCreator {
+		// When a contract is created via CREATE/CREATE2, the creator's nonce is
+		// incremented. The EVM does not revert this when the CREATE frame itself
+		// fails (the nonce change happens before the EVM snapshot). However, if
+		// a parent frame reverts, the nonce must be reverted along with everything
+		// else.
+		//
+		// To achieve this, advance the current frame's revision point past this
+		// entry. The CREATE frame's revert won't touch it (it's below the revision),
+		// but a parent frame's revert will (it's above the parent's revision).
+		j.revisions[len(j.revisions)-1] = len(j.entries)
+	}
+	if j.hooks.OnNonceChangeV2 != nil {
+		j.hooks.OnNonceChangeV2(addr, prev, new, reason)
+	} else if j.hooks.OnNonceChange != nil {
+		j.hooks.OnNonceChange(addr, prev, new)
+	}
+}
+
+func (j *journal) OnCodeChange(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte) {
+	j.entries = append(j.entries, codeChange{
+		addr:         addr,
+		prevCodeHash: prevCodeHash,
+		prevCode:     prevCode,
+		newCodeHash:  codeHash,
+		newCode:      code,
+	})
+	if j.hooks.OnCodeChange != nil {
+		j.hooks.OnCodeChange(addr, prevCodeHash, prevCode, codeHash, code)
+	}
+}
+
+func (j *journal) OnStorageChange(addr common.Address, slot common.Hash, prev, new common.Hash) {
+	j.entries = append(j.entries, storageChange{addr: addr, slot: slot, prev: prev, new: new})
+	if j.hooks.OnStorageChange != nil {
+		j.hooks.OnStorageChange(addr, slot, prev, new)
+	}
+}
+
+type (
+	balanceChange struct {
+		addr common.Address
+		prev *big.Int
+		new  *big.Int
+	}
+
+	nonceChange struct {
+		addr common.Address
+		prev uint64
+		new  uint64
+	}
+
+	codeChange struct {
+		addr         common.Address
+		prevCodeHash common.Hash
+		prevCode     []byte
+		newCodeHash  common.Hash
+		newCode      []byte
+	}
+
+	storageChange struct {
+		addr common.Address
+		slot common.Hash
+		prev common.Hash
+		new  common.Hash
+	}
+)
+
+func (b balanceChange) revert(hooks *Hooks) {
+	if hooks.OnBalanceChange != nil {
+		hooks.OnBalanceChange(b.addr, b.new, b.prev, BalanceChangeRevert)
+	}
+}
+
+func (n nonceChange) revert(hooks *Hooks) {
+	if hooks.OnNonceChangeV2 != nil {
+		hooks.OnNonceChangeV2(n.addr, n.new, n.prev, NonceChangeRevert)
+	} else if hooks.OnNonceChange != nil {
+		hooks.OnNonceChange(n.addr, n.new, n.prev)
+	}
+}
+
+func (c codeChange) revert(hooks *Hooks) {
+	if hooks.OnCodeChange != nil {
+		hooks.OnCodeChange(c.addr, c.newCodeHash, c.newCode, c.prevCodeHash, c.prevCode)
+	}
+}
+
+func (s storageChange) revert(hooks *Hooks) {
+	if hooks.OnStorageChange != nil {
+		hooks.OnStorageChange(s.addr, s.slot, s.new, s.prev)
+	}
+}

--- a/core/tracing/journal_test.go
+++ b/core/tracing/journal_test.go
@@ -1,0 +1,354 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tracing
+
+import (
+	"errors"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+)
+
+type testTracer struct {
+	t       *testing.T
+	bal     *big.Int
+	nonce   uint64
+	code    []byte
+	storage map[common.Hash]common.Hash
+}
+
+func (t *testTracer) OnBalanceChange(addr common.Address, prev *big.Int, new *big.Int, reason BalanceChangeReason) {
+	t.t.Logf("OnBalanceChange(%v, %v -> %v, %v)", addr, prev, new, reason)
+	if t.bal != nil && t.bal.Cmp(prev) != 0 {
+		t.t.Errorf("  !! wrong prev balance (expected %v)", t.bal)
+	}
+	t.bal = new
+}
+
+func (t *testTracer) OnNonceChange(addr common.Address, prev uint64, new uint64) {
+	t.t.Logf("OnNonceChange(%v, %v -> %v)", addr, prev, new)
+	t.nonce = new
+}
+
+func (t *testTracer) OnNonceChangeV2(addr common.Address, prev uint64, new uint64, reason NonceChangeReason) {
+	t.t.Logf("OnNonceChangeV2(%v, %v -> %v, %v)", addr, prev, new, reason)
+	t.nonce = new
+}
+
+func (t *testTracer) OnCodeChange(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte) {
+	t.t.Logf("OnCodeChange(%v, %v -> %v)", addr, prevCodeHash, codeHash)
+	t.code = code
+}
+
+func (t *testTracer) OnStorageChange(addr common.Address, slot common.Hash, prev common.Hash, new common.Hash) {
+	t.t.Logf("OnStorageChange(%v, %v, %v -> %v)", addr, slot, prev, new)
+	if t.storage == nil {
+		t.storage = make(map[common.Hash]common.Hash)
+	}
+	if new == (common.Hash{}) {
+		delete(t.storage, slot)
+	} else {
+		t.storage[slot] = new
+	}
+}
+
+func TestJournalIntegration(t *testing.T) {
+	tr := &testTracer{t: t}
+	wr, err := WrapWithJournal(&Hooks{OnBalanceChange: tr.OnBalanceChange, OnNonceChange: tr.OnNonceChange, OnCodeChange: tr.OnCodeChange, OnStorageChange: tr.OnStorageChange})
+	if err != nil {
+		t.Fatalf("failed to wrap test tracer: %v", err)
+	}
+
+	addr := common.HexToAddress("0x1234")
+	{
+		wr.OnEnter(0, 0, addr, addr, nil, 1000, big.NewInt(0))
+		wr.OnBalanceChange(addr, nil, big.NewInt(100), BalanceChangeUnspecified)
+		wr.OnCodeChange(addr, common.Hash{}, nil, common.Hash{}, []byte{1, 2, 3})
+		wr.OnStorageChange(addr, common.Hash{1}, common.Hash{}, common.Hash{2})
+		{
+			wr.OnEnter(1, 0, addr, addr, nil, 1000, big.NewInt(0))
+			wr.OnNonceChangeV2(addr, 0, 1, NonceChangeUnspecified)
+			wr.OnBalanceChange(addr, big.NewInt(100), big.NewInt(200), BalanceChangeUnspecified)
+			wr.OnBalanceChange(addr, big.NewInt(200), big.NewInt(250), BalanceChangeUnspecified)
+			wr.OnStorageChange(addr, common.Hash{1}, common.Hash{2}, common.Hash{3})
+			wr.OnStorageChange(addr, common.Hash{2}, common.Hash{}, common.Hash{4})
+			wr.OnExit(1, nil, 100, errors.New("revert"), true)
+		}
+		wr.OnExit(0, nil, 150, nil, false)
+	}
+
+	if tr.bal.Cmp(big.NewInt(100)) != 0 {
+		t.Fatalf("unexpected balance: %v", tr.bal)
+	}
+	if tr.nonce != 0 {
+		t.Fatalf("unexpected nonce: %v", tr.nonce)
+	}
+	if len(tr.code) != 3 {
+		t.Fatalf("unexpected code: %v", tr.code)
+	}
+	if len(tr.storage) != 1 {
+		t.Fatalf("unexpected storage len. want %d, have %d", 1, len(tr.storage))
+	}
+	if tr.storage[common.Hash{1}] != (common.Hash{2}) {
+		t.Fatalf("unexpected storage. want %v, have %v", common.Hash{2}, tr.storage[common.Hash{1}])
+	}
+}
+
+func TestJournalTopRevert(t *testing.T) {
+	tr := &testTracer{t: t}
+	wr, err := WrapWithJournal(&Hooks{OnBalanceChange: tr.OnBalanceChange, OnNonceChange: tr.OnNonceChange})
+	if err != nil {
+		t.Fatalf("failed to wrap test tracer: %v", err)
+	}
+
+	addr := common.HexToAddress("0x1234")
+	{
+		wr.OnEnter(0, 0, addr, addr, nil, 1000, big.NewInt(0))
+		wr.OnBalanceChange(addr, big.NewInt(0), big.NewInt(100), BalanceChangeUnspecified)
+		{
+			wr.OnEnter(1, 0, addr, addr, nil, 1000, big.NewInt(0))
+			wr.OnNonceChangeV2(addr, 0, 1, NonceChangeUnspecified)
+			wr.OnBalanceChange(addr, big.NewInt(100), big.NewInt(200), BalanceChangeUnspecified)
+			wr.OnBalanceChange(addr, big.NewInt(200), big.NewInt(250), BalanceChangeUnspecified)
+			wr.OnExit(1, nil, 100, errors.New("revert"), true)
+		}
+		wr.OnExit(0, nil, 150, errors.New("revert"), true)
+	}
+
+	if tr.bal.Cmp(big.NewInt(0)) != 0 {
+		t.Fatalf("unexpected balance: %v", tr.bal)
+	}
+	if tr.nonce != 0 {
+		t.Fatalf("unexpected nonce: %v", tr.nonce)
+	}
+}
+
+func TestJournalNestedCalls(t *testing.T) {
+	tr := &testTracer{t: t}
+	wr, err := WrapWithJournal(&Hooks{OnBalanceChange: tr.OnBalanceChange, OnNonceChange: tr.OnNonceChange})
+	if err != nil {
+		t.Fatalf("failed to wrap test tracer: %v", err)
+	}
+
+	addr := common.HexToAddress("0x1234")
+	{
+		wr.OnEnter(0, 0, addr, addr, nil, 1000, big.NewInt(0))
+		wr.OnBalanceChange(addr, big.NewInt(0), big.NewInt(100), BalanceChangeUnspecified)
+		{
+			wr.OnEnter(1, 0, addr, addr, nil, 1000, big.NewInt(0))
+			wr.OnBalanceChange(addr, big.NewInt(100), big.NewInt(200), BalanceChangeUnspecified)
+			{
+				wr.OnEnter(2, 0, addr, addr, nil, 1000, big.NewInt(0))
+				wr.OnExit(2, nil, 100, nil, false)
+			}
+			{
+				wr.OnEnter(2, 0, addr, addr, nil, 1000, big.NewInt(0))
+				wr.OnBalanceChange(addr, big.NewInt(200), big.NewInt(300), BalanceChangeUnspecified)
+				wr.OnExit(2, nil, 100, nil, false)
+			}
+			{
+				wr.OnEnter(2, 0, addr, addr, nil, 1000, big.NewInt(0))
+				wr.OnExit(2, nil, 100, nil, false)
+			}
+			wr.OnBalanceChange(addr, big.NewInt(300), big.NewInt(400), BalanceChangeUnspecified)
+			{
+				wr.OnEnter(2, 0, addr, addr, nil, 1000, big.NewInt(0))
+				wr.OnBalanceChange(addr, big.NewInt(400), big.NewInt(500), BalanceChangeUnspecified)
+				wr.OnExit(2, nil, 100, errors.New("revert"), true)
+			}
+			{
+				wr.OnEnter(2, 0, addr, addr, nil, 1000, big.NewInt(0))
+				wr.OnExit(2, nil, 100, errors.New("revert"), true)
+			}
+			{
+				wr.OnEnter(2, 0, addr, addr, nil, 1000, big.NewInt(0))
+				wr.OnBalanceChange(addr, big.NewInt(400), big.NewInt(600), BalanceChangeUnspecified)
+				wr.OnExit(2, nil, 100, nil, false)
+			}
+			wr.OnExit(1, nil, 100, errors.New("revert"), true)
+		}
+		wr.OnExit(0, nil, 150, nil, false)
+	}
+
+	if tr.bal.Uint64() != 100 {
+		t.Fatalf("unexpected balance: %v", tr.bal)
+	}
+}
+
+func TestNonceIncOnCreate(t *testing.T) {
+	const opCREATE = 0xf0
+
+	tr := &testTracer{t: t}
+	wr, err := WrapWithJournal(&Hooks{OnNonceChange: tr.OnNonceChange})
+	if err != nil {
+		t.Fatalf("failed to wrap test tracer: %v", err)
+	}
+
+	addr := common.HexToAddress("0x1234")
+	{
+		wr.OnEnter(0, opCREATE, addr, addr, nil, 1000, big.NewInt(0))
+		wr.OnNonceChangeV2(addr, 0, 1, NonceChangeContractCreator)
+		wr.OnExit(0, nil, 100, errors.New("revert"), true)
+	}
+
+	if tr.nonce != 1 {
+		t.Fatalf("unexpected nonce: %v", tr.nonce)
+	}
+}
+
+// TestNonceIncOnCreateParentReverts checks that the creator's nonce increment
+// from CREATE survives the CREATE frame's own revert but is properly reverted
+// when the parent call frame reverts.
+func TestNonceIncOnCreateParentReverts(t *testing.T) {
+	const opCREATE = 0xf0
+
+	tr := &testTracer{t: t}
+	wr, err := WrapWithJournal(&Hooks{OnNonceChange: tr.OnNonceChange})
+	if err != nil {
+		t.Fatalf("failed to wrap test tracer: %v", err)
+	}
+
+	addr := common.HexToAddress("0x1234")
+	{
+		// Parent call frame
+		wr.OnEnter(0, 0, addr, addr, nil, 1000, big.NewInt(0))
+		{
+			// CREATE frame — creator nonce incremented, then CREATE reverts
+			wr.OnEnter(1, opCREATE, addr, addr, nil, 1000, big.NewInt(0))
+			wr.OnNonceChangeV2(addr, 0, 1, NonceChangeContractCreator)
+			wr.OnExit(1, nil, 100, errors.New("revert"), true)
+		}
+		// After CREATE reverts, nonce should still be 1
+		if tr.nonce != 1 {
+			t.Fatalf("nonce after CREATE revert: got %v, want 1", tr.nonce)
+		}
+		// Parent frame also reverts
+		wr.OnExit(0, nil, 150, errors.New("revert"), true)
+	}
+
+	// After parent reverts, nonce should be back to 0
+	if tr.nonce != 0 {
+		t.Fatalf("nonce after parent revert: got %v, want 0", tr.nonce)
+	}
+}
+
+func TestOnNonceChangeV2(t *testing.T) {
+	tr := &testTracer{t: t}
+	wr, err := WrapWithJournal(&Hooks{OnNonceChangeV2: tr.OnNonceChangeV2})
+	if err != nil {
+		t.Fatalf("failed to wrap test tracer: %v", err)
+	}
+
+	addr := common.HexToAddress("0x1234")
+	{
+		wr.OnEnter(2, 0, addr, addr, nil, 1000, big.NewInt(0))
+		wr.OnNonceChangeV2(addr, 0, 1, NonceChangeEoACall)
+		wr.OnExit(2, nil, 100, nil, true)
+	}
+
+	if tr.nonce != 0 {
+		t.Fatalf("unexpected nonce: %v", tr.nonce)
+	}
+}
+
+func TestAllHooksCalled(t *testing.T) {
+	tracer := newTracerAllHooks()
+	hooks := tracer.hooks()
+
+	wrapped, err := WrapWithJournal(hooks)
+	if err != nil {
+		t.Fatalf("failed to wrap hooks with journal: %v", err)
+	}
+
+	wrappedValue := reflect.ValueOf(wrapped).Elem()
+	wrappedType := wrappedValue.Type()
+
+	for i := 0; i < wrappedType.NumField(); i++ {
+		field := wrappedType.Field(i)
+		if field.Type.Kind() != reflect.Func {
+			continue
+		}
+		if wrappedValue.Field(i).IsNil() {
+			continue
+		}
+
+		method := wrappedValue.Field(i)
+		params := make([]reflect.Value, method.Type().NumIn())
+		for j := 0; j < method.Type().NumIn(); j++ {
+			params[j] = reflect.Zero(method.Type().In(j))
+		}
+		method.Call(params)
+	}
+
+	if tracer.numCalled() != tracer.hooksCount() {
+		t.Errorf("Not all hooks were called. Expected %d, got %d", tracer.hooksCount(), tracer.numCalled())
+	}
+
+	for hookName, called := range tracer.hooksCalled {
+		if !called {
+			t.Errorf("Hook %s was not called", hookName)
+		}
+	}
+}
+
+type tracerAllHooks struct {
+	hooksCalled map[string]bool
+}
+
+func newTracerAllHooks() *tracerAllHooks {
+	t := &tracerAllHooks{hooksCalled: make(map[string]bool)}
+	hooksType := reflect.TypeOf((*Hooks)(nil)).Elem()
+	for i := 0; i < hooksType.NumField(); i++ {
+		t.hooksCalled[hooksType.Field(i).Name] = false
+	}
+	delete(t.hooksCalled, "OnNonceChange")
+	return t
+}
+
+func (t *tracerAllHooks) hooksCount() int {
+	return len(t.hooksCalled)
+}
+
+func (t *tracerAllHooks) numCalled() int {
+	count := 0
+	for _, called := range t.hooksCalled {
+		if called {
+			count++
+		}
+	}
+	return count
+}
+
+func (t *tracerAllHooks) hooks() *Hooks {
+	h := &Hooks{}
+	hooksValue := reflect.ValueOf(h).Elem()
+	for i := 0; i < hooksValue.NumField(); i++ {
+		field := hooksValue.Type().Field(i)
+		if field.Name == "OnNonceChange" {
+			continue
+		}
+		hookName := field.Name
+		hookMethod := reflect.MakeFunc(field.Type, func(args []reflect.Value) []reflect.Value {
+			t.hooksCalled[hookName] = true
+			return nil
+		})
+		hooksValue.Field(i).Set(hookMethod)
+	}
+	return h
+}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -531,7 +531,7 @@ func TestPromoteExecutablesQueueEmptyWithoutReservation(t *testing.T) {
 	r.lock.Unlock()
 
 	pool.mu.Lock()
-	pool.currentState.SetNonce(addr, 10)
+	pool.currentState.SetNonce(addr, 10, tracing.NonceChangeUnspecified)
 	pool.promoteExecutables([]common.Address{addr})
 	pool.mu.Unlock()
 
@@ -557,7 +557,7 @@ func (c *testChain) State() (*state.StateDB, error) {
 	if *c.trigger {
 		c.statedb, _ = state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()))
 		// simulate that the new head block included tx0 and tx1
-		c.statedb.SetNonce(c.address, 2)
+		c.statedb.SetNonce(c.address, 2, tracing.NonceChangeUnspecified)
 		c.statedb.SetBalance(c.address, new(big.Int).SetUint64(params.Ether), tracing.BalanceChangeUnspecified)
 		*c.trigger = false
 	}
@@ -619,7 +619,7 @@ func testAddBalance(pool *LegacyPool, addr common.Address, amount *big.Int) {
 
 func testSetNonce(pool *LegacyPool, addr common.Address, nonce uint64) {
 	pool.mu.Lock()
-	pool.currentState.SetNonce(addr, nonce)
+	pool.currentState.SetNonce(addr, nonce, tracing.NonceChangeUnspecified)
 	pool.mu.Unlock()
 }
 
@@ -1402,7 +1402,7 @@ func TestQueueTimeLimiting(t *testing.T) {
 	}
 
 	// remove current transactions and increase nonce to prepare for a reset and cleanup
-	statedb.SetNonce(crypto.PubkeyToAddress(remote.PublicKey), 2)
+	statedb.SetNonce(crypto.PubkeyToAddress(remote.PublicKey), 2, tracing.NonceChangeUnspecified)
 	<-pool.requestReset(nil, nil)
 
 	// make sure queue, pending are cleared
@@ -2906,7 +2906,7 @@ func TestSetCodeTransactionsReorg(t *testing.T) {
 		t.Fatalf("failed to add with remote setcode transaction: %v", err)
 	}
 	// Simulate the chain moving
-	blockchain.statedb.SetNonce(addrA, 1)
+	blockchain.statedb.SetNonce(addrA, 1, tracing.NonceChangeUnspecified)
 	blockchain.statedb.SetCode(addrA, types.AddressToDelegation(auth.Address))
 	<-pool.requestReset(nil, nil)
 	// Set an authorization for 0x00
@@ -2924,7 +2924,7 @@ func TestSetCodeTransactionsReorg(t *testing.T) {
 		t.Fatalf("unexpected error %v, expecting %v", err, txpool.ErrInflightTxLimitReached)
 	}
 	// Simulate the chain moving
-	blockchain.statedb.SetNonce(addrA, 2)
+	blockchain.statedb.SetNonce(addrA, 2, tracing.NonceChangeUnspecified)
 	blockchain.statedb.SetCode(addrA, nil)
 	<-pool.requestReset(nil, nil)
 	// Now send two transactions from addrA

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -468,7 +468,7 @@ func (evm *EVM) create(caller common.Address, code []byte, gas uint64, value *ui
 	if nonce+1 < nonce {
 		return nil, common.Address{}, gas, ErrNonceUintOverflow
 	}
-	evm.StateDB.SetNonce(caller, nonce+1)
+	evm.StateDB.SetNonce(caller, nonce+1, tracing.NonceChangeContractCreator)
 
 	// We add this to the access list _before_ taking a snapshot. Even if the creation fails,
 	// the access-list change should not be rolled back
@@ -504,7 +504,7 @@ func (evm *EVM) create(caller common.Address, code []byte, gas uint64, value *ui
 	evm.StateDB.CreateContract(address)
 
 	if evm.chainRules.IsEIP158 {
-		evm.StateDB.SetNonce(address, 1)
+		evm.StateDB.SetNonce(address, 1, tracing.NonceChangeNewContract)
 	}
 	evm.Context.Transfer(evm.StateDB, caller, address, value)
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -437,6 +437,7 @@ func opBlockhash(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		num.Clear()
 		return nil, nil
 	}
+
 	var upper, lower uint64
 	upper = evm.Context.BlockNumber.Uint64()
 	if upper < 257 {
@@ -445,7 +446,11 @@ func opBlockhash(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		lower = upper - 256
 	}
 	if num64 >= lower && num64 < upper {
-		num.SetBytes(evm.Context.GetHash(num64).Bytes())
+		hash := evm.Context.GetHash(num64)
+		if tracer := evm.Config.Tracer; tracer != nil && tracer.OnBlockHashRead != nil {
+			tracer.OnBlockHashRead(num64, hash)
+		}
+		num.SetBytes(hash[:])
 	} else {
 		num.Clear()
 	}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -35,7 +35,7 @@ type StateDB interface {
 	GetBalance(common.Address) *big.Int
 
 	GetNonce(common.Address) uint64
-	SetNonce(common.Address, uint64)
+	SetNonce(common.Address, uint64, tracing.NonceChangeReason)
 
 	GetCodeHash(common.Address) common.Hash
 	GetCode(common.Address) []byte

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -417,7 +417,7 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, tracerCode 
 	eoa := common.HexToAddress("E0")
 	{
 		cfg.State.CreateAccount(eoa)
-		cfg.State.SetNonce(eoa, 100)
+		cfg.State.SetNonce(eoa, 100, tracing.NonceChangeUnspecified)
 	}
 	reverting := common.HexToAddress("EE")
 	{

--- a/eth/tracers/live/noop.go
+++ b/eth/tracers/live/noop.go
@@ -57,6 +57,7 @@ func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, error) {
 		OnCodeChange:     t.OnCodeChange,
 		OnStorageChange:  t.OnStorageChange,
 		OnLog:            t.OnLog,
+		OnBlockHashRead:  t.OnBlockHashRead,
 	}, nil
 }
 
@@ -106,6 +107,9 @@ func (t *noop) OnStorageChange(a common.Address, k, prev, new common.Hash) {
 
 func (t *noop) OnLog(l *types.Log) {
 
+}
+
+func (t *noop) OnBlockHashRead(number uint64, hash common.Hash) {
 }
 
 func (t *noop) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -94,7 +94,7 @@ func (diff *StateOverride) Apply(statedb *state.StateDB, precompiles vm.Precompi
 		}
 		// Override account nonce.
 		if account.Nonce != nil {
-			statedb.SetNonce(addr, uint64(*account.Nonce))
+			statedb.SetNonce(addr, uint64(*account.Nonce), tracing.NonceChangeUnspecified)
 		}
 		// Override account(contract) code.
 		if account.Code != nil {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -220,7 +220,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc) *state.StateDB
 	statedb, _ := state.New(types.EmptyRootHash, sdb)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)
-		statedb.SetNonce(addr, a.Nonce)
+		statedb.SetNonce(addr, a.Nonce, tracing.NonceChangeGenesis)
 		statedb.SetBalance(addr, a.Balance, tracing.BalanceChangeUnspecified)
 		for k, v := range a.Storage {
 			statedb.SetState(addr, k, v)


### PR DESCRIPTION
# Proposed changes

add some more changes for live tracing API:

- Hook OnSystemCallStartV2 was introduced with VMContext as parameter.
- Hook OnBlockHashRead was introduced.
- GetCodeHash was added to the state interface
- The new WrapWithJournal construction helps with tracking EVM reverts in the tracer.

Ref: 

- #30441
- #33978


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [X] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
