### PR TITLE
fix(cmd/utils/flags): disable HTTP and WS-RPC servers by default

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -472,7 +472,7 @@ var (
 		Name:     "http",
 		Aliases:  []string{"rpc"},
 		Usage:    "Enable the HTTP-RPC server",
-		Value:    true,
+		Value:    false,
 		Category: flags.APICategory,
 	}
 	HTTPListenAddrFlag = &cli.StringFlag{
@@ -507,7 +507,7 @@ var (
 		Name:     "http-api",
 		Aliases:  []string{"rpcapi"},
 		Usage:    "API's offered over the HTTP-RPC interface",
-		Value:    "debug,eth,net,txpool,web3,XDPoS",
+		Value:    "eth,net,txpool,web3,XDPoS",
 		Category: flags.APICategory,
 	}
 	HTTPPathPrefixFlag = &cli.StringFlag{
@@ -546,7 +546,7 @@ var (
 	WSEnabledFlag = &cli.BoolFlag{
 		Name:     "ws",
 		Usage:    "Enable the WS-RPC server",
-		Value:    true,
+		Value:    false,
 		Category: flags.APICategory,
 	}
 	WSListenAddrFlag = &cli.StringFlag{
@@ -567,7 +567,7 @@ var (
 		Name:     "ws-api",
 		Aliases:  []string{"wsapi"},
 		Usage:    "API's offered over the WS-RPC interface",
-		Value:    "debug,eth,net,txpool,web3,XDPoS",
+		Value:    "eth,net,txpool,web3,XDPoS",
 		Category: flags.APICategory,
 	}
 	WSAllowedOriginsFlag = &cli.StringFlag{


### PR DESCRIPTION
# Proposed changes

**Problem**: Node enables RPC and debug API by default → security risk  
**Fix**: Set `--http` / `--ws` default to `false`, and remove `debug` from default API lists  

| | Before | After |  
|---|---|---|  
| RPC | Enabled by default | Only starts if `--http` / `--ws` is explicitly passed |  
| debug API | Included by default | Must be added manually (e.g., `--http.api=eth,debug`) |


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [x] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
