### PR TITLE
fix(api): XDPoS_getRewardByAccount to be able to parse scientific notation

### DIFF
--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -633,7 +633,7 @@ func jsonNumberToBigInt(n json.Number) (*big.Int, bool) {
 	i, acc := f.Int(nil)
 	if acc != big.Exact {
 		// The value had a fractional part; truncate is the best we can do
-		log.Debug("[jsonNumberToBigInt] json.Number had fractional part, truncated to integer", "number", s, "truncated", i.String(), "accuracy", acc)
+		log.Warn("[jsonNumberToBigInt] json.Number is not an exact integer value", "number", s, "truncated", i.String(), "accuracy", acc)
 	}
 
 	return i, true

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -614,20 +614,43 @@ func getEpochReward(account common.Address, header *types.Header) (AccountEpochR
 	return epochReward, nil
 }
 
+// jsonNumberToBigInt parses a json.Number into a *big.Int, handling both plain
+// decimal strings (e.g. "4500000000000000000") and scientific notation
+// (e.g. "4.5e+21") that big.Int.SetString cannot parse directly.
+func jsonNumberToBigInt(n json.Number) (*big.Int, bool) {
+	s := n.String()
+	// Try plain integer first — the common case.
+	if i, ok := new(big.Int).SetString(s, 10); ok {
+		return i, true
+	}
+	// Fall back to big.Float to handle scientific notation.
+	f, _, err := new(big.Float).SetPrec(256).Parse(s, 10)
+	if err != nil {
+		log.Warn("[jsonNumberToBigInt] Failed to parse json.Number:", "number", s, "err", err)
+		return nil, false
+	}
+
+	i, acc := f.Int(nil)
+	if acc != big.Exact {
+		// The value had a fractional part; truncate is the best we can do
+		log.Debug("[jsonNumberToBigInt] json.Number had fractional part, truncated to integer", "number", s, "truncated", i.String(), "accuracy", acc)
+	}
+
+	return i, true
+}
+
 func (rewardObj *AccountEpochReward) getRewardAndStatus(account string, data map[string]interface{}) {
 	if signersData, exists := data["signers"]; exists {
 		if accountData, ok := signersData.(map[string]interface{})[account]; ok {
 			nodeReward := accountData.(map[string]interface{})["reward"]
 			delegatedReward := data["rewards"].(map[string]interface{})[account]
 			rewardObj.AccountStatus = statusMasternode
-			nodeRewardBigInt, ok := new(big.Int).SetString(nodeReward.(json.Number).String(), 10)
-			if ok {
+			if nodeRewardBigInt, ok := jsonNumberToBigInt(nodeReward.(json.Number)); ok {
 				rewardObj.AccountReward = nodeRewardBigInt
 			}
 
 			for k, v := range delegatedReward.(map[string]interface{}) {
-				delegatedBigInt, ok := new(big.Int).SetString(v.(json.Number).String(), 10)
-				if ok {
+				if delegatedBigInt, ok := jsonNumberToBigInt(v.(json.Number)); ok {
 					rewardObj.DelegatedReward[k] = delegatedBigInt
 				}
 			}
@@ -640,14 +663,12 @@ func (rewardObj *AccountEpochReward) getRewardAndStatus(account string, data map
 			nodeReward := accountData.(map[string]interface{})["reward"]
 			delegatedReward := data["rewardsProtector"].(map[string]interface{})[account]
 			rewardObj.AccountStatus = statusProtectornode
-			nodeRewardBigInt, successSetNodeReward := new(big.Int).SetString(nodeReward.(json.Number).String(), 10)
-			if successSetNodeReward {
+			if nodeRewardBigInt, ok := jsonNumberToBigInt(nodeReward.(json.Number)); ok {
 				rewardObj.AccountReward = nodeRewardBigInt
 			}
 
 			for k, v := range delegatedReward.(map[string]interface{}) {
-				delegatedBigInt, successSetDelegatedReward := new(big.Int).SetString(v.(json.Number).String(), 10)
-				if successSetDelegatedReward {
+				if delegatedBigInt, ok := jsonNumberToBigInt(v.(json.Number)); ok {
 					rewardObj.DelegatedReward[k] = delegatedBigInt
 				}
 			}
@@ -660,14 +681,12 @@ func (rewardObj *AccountEpochReward) getRewardAndStatus(account string, data map
 			nodeReward := accountData.(map[string]interface{})["reward"]
 			delegatedReward := data["rewardsObserver"].(map[string]interface{})[account]
 			rewardObj.AccountStatus = statusObservernode
-			nodeRewardBigInt, successSetNodeReward := new(big.Int).SetString(nodeReward.(json.Number).String(), 10)
-			if successSetNodeReward {
+			if nodeRewardBigInt, ok := jsonNumberToBigInt(nodeReward.(json.Number)); ok {
 				rewardObj.AccountReward = nodeRewardBigInt
 			}
 
 			for k, v := range delegatedReward.(map[string]interface{}) {
-				delegatedBigInt, successSetDelegatedReward := new(big.Int).SetString(v.(json.Number).String(), 10)
-				if successSetDelegatedReward {
+				if delegatedBigInt, ok := jsonNumberToBigInt(v.(json.Number)); ok {
 					rewardObj.DelegatedReward[k] = delegatedBigInt
 				}
 			}

--- a/consensus/XDPoS/api_test.go
+++ b/consensus/XDPoS/api_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateSignersVote(t *testing.T) {
@@ -156,11 +157,11 @@ func TestJsonNumberToBigInt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := jsonNumberToBigInt(tt.input)
 			if tt.wantOk {
-				assert.True(t, ok, "input %q: parse failed, expected %s", tt.input, tt.want)
+				require.True(t, ok, "input %q: parse failed, expected %s", tt.input, tt.want)
 				assert.Equal(t, 0, tt.want.Cmp(got), "input %q: expected %s but got %s", tt.input, tt.want, got)
 			} else {
-				assert.False(t, ok, "input %q: expected parse failure but got %s", tt.input, got)
-				assert.Nil(t, got, "input %q: expected nil but got %s", tt.input, got)
+				assert.False(t, ok, "input %q: expected parse failure but got %v", tt.input, got)
+				assert.Nil(t, got, "input %q: expected nil but got %v", tt.input, got)
 			}
 		})
 	}

--- a/consensus/XDPoS/api_test.go
+++ b/consensus/XDPoS/api_test.go
@@ -1,6 +1,7 @@
 package XDPoS
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -68,4 +69,99 @@ func TestCalculateSignersTimeout(t *testing.T) {
 
 	calculateSigners(info, timeouts.Get(), masternodes)
 	assert.Equal(t, info["10:450"].CurrentNumber, 2)
+}
+
+func TestJsonNumberToBigInt(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  json.Number
+		want   *big.Int
+		wantOk bool
+	}{
+		{
+			name:   "plain decimal integer",
+			input:  json.Number("4500000000000000000000"),
+			want:   new(big.Int).Mul(big.NewInt(45), new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil)),
+			wantOk: true,
+		},
+		{
+			name:   "scientific notation 4.5e+21",
+			input:  json.Number("4.5e+21"),
+			want:   new(big.Int).Mul(big.NewInt(45), new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil)),
+			wantOk: true,
+		},
+		{
+			name:   "scientific notation 1e+18",
+			input:  json.Number("1e+18"),
+			want:   new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+			wantOk: true,
+		},
+		{
+			name:   "scientific notation uppercase E",
+			input:  json.Number("4.5E+21"),
+			want:   new(big.Int).Mul(big.NewInt(45), new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil)),
+			wantOk: true,
+		},
+		{
+			name:   "zero",
+			input:  json.Number("0"),
+			want:   big.NewInt(0),
+			wantOk: true,
+		},
+		{
+			name:   "small integer",
+			input:  json.Number("12345"),
+			want:   big.NewInt(12345),
+			wantOk: true,
+		},
+		{
+			name:   "fractional value truncates",
+			input:  json.Number("1.23e+1"),
+			want:   big.NewInt(12),
+			wantOk: true,
+		},
+		{
+			name:   "decimal without exponent",
+			input:  json.Number("123.456"),
+			want:   big.NewInt(123),
+			wantOk: true,
+		},
+		{
+			name:   "decimal whole number",
+			input:  json.Number("1000.0"),
+			want:   big.NewInt(1000),
+			wantOk: true,
+		},
+		{
+			name:   "negative integer",
+			input:  json.Number("-500"),
+			want:   big.NewInt(-500),
+			wantOk: true,
+		},
+		{
+			name:   "invalid string",
+			input:  json.Number("not_a_number"),
+			want:   nil,
+			wantOk: false,
+		},
+		{
+			name:   "empty string",
+			input:  json.Number(""),
+			want:   nil,
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := jsonNumberToBigInt(tt.input)
+			if tt.wantOk {
+				assert.True(t, ok, "input %q: parse failed, expected %s", tt.input, tt.want)
+				assert.Equal(t, 0, tt.want.Cmp(got), "input %q: expected %s but got %s", tt.input, tt.want, got)
+			} else {
+				assert.False(t, ok, "input %q: expected parse failure but got %s", tt.input, got)
+				assert.Nil(t, got, "input %q: expected nil but got %s", tt.input, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
# Proposed changes

fix api XDPoS_getRewardByAccount to be able to parse scientific not

added unit tests

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
