### PR TITLE
fix(p2p,eth): synchronize pair peer teardown

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -534,9 +534,9 @@ func (ps *peerSet) Register(p *peer) error {
 		if existPeer.pairRw != nil {
 			return errAlreadyRegistered
 		}
-		existPeer.PairPeer = p.Peer
+		existPeer.SetPairPeer(p.Peer)
 		existPeer.pairRw = p.rw
-		p.PairPeer = existPeer.Peer
+		p.SetPairPeer(existPeer.Peer)
 		return p2p.ErrAddPairPeer
 	}
 	ps.peers[p.id] = p

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -266,8 +266,8 @@ func (s *dialstate) checkDial(n *discover.Node, peers map[discover.NodeID]*Peer)
 	case dialing:
 		return errAlreadyDialing
 	case peers[n.ID] != nil:
-		exitsPeer := peers[n.ID]
-		if exitsPeer.PairPeer != nil {
+		existPeer := peers[n.ID]
+		if existPeer.PairPeer() != nil {
 			return errAlreadyConnected
 		}
 	case s.ntab != nil && n.ID == s.ntab.Self().ID:

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -113,8 +113,10 @@ type Peer struct {
 	disc     chan DiscReason
 
 	// events receives message send / receive events if set
-	events   *event.Feed
-	PairPeer *Peer
+	events *event.Feed
+
+	pairPeerMu sync.RWMutex
+	pairPeer   *Peer
 }
 
 // NewPeer returns a peer for testing purposes.
@@ -190,6 +192,30 @@ func (p *Peer) Log() log.Logger {
 	return p.log
 }
 
+func (p *Peer) PairPeer() *Peer {
+	p.pairPeerMu.RLock()
+	defer p.pairPeerMu.RUnlock()
+
+	return p.pairPeer
+}
+
+func (p *Peer) SetPairPeer(pair *Peer) {
+	p.pairPeerMu.Lock()
+	p.pairPeer = pair
+	p.pairPeerMu.Unlock()
+}
+
+func (p *Peer) ClearPairPeer(pair *Peer) bool {
+	p.pairPeerMu.Lock()
+	defer p.pairPeerMu.Unlock()
+
+	if p.pairPeer != pair {
+		return false
+	}
+	p.pairPeer = nil
+	return true
+}
+
 func (p *Peer) run() (remoteRequested bool, err error) {
 	var (
 		writeStart = make(chan struct{}, 1)
@@ -235,8 +261,8 @@ loop:
 	close(p.closed)
 	p.rw.close(reason)
 	p.wg.Wait()
-	if p.PairPeer != nil {
-		go func() { p.PairPeer.Disconnect(DiscPairPeerStop) }()
+	if pairPeer := p.PairPeer(); pairPeer != nil {
+		go pairPeer.Disconnect(DiscPairPeerStop)
 	}
 	return remoteRequested, err
 }

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -197,6 +197,34 @@ func TestPeerDisconnectRace(t *testing.T) {
 	}
 }
 
+func TestPeerRunDisconnectsPairPeer(t *testing.T) {
+	closer, _, peer, errc := testPeer(nil)
+	defer closer()
+
+	pairPeer := &Peer{
+		disc:   make(chan DiscReason, 1),
+		closed: make(chan struct{}),
+	}
+	peer.SetPairPeer(pairPeer)
+
+	closer()
+
+	select {
+	case <-errc:
+	case <-time.After(2 * time.Second):
+		t.Fatal("peer did not stop")
+	}
+
+	select {
+	case reason := <-pairPeer.disc:
+		if reason != DiscPairPeerStop {
+			t.Fatalf("unexpected pair disconnect reason: got %v want %v", reason, DiscPairPeerStop)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pair peer was not disconnected")
+	}
+}
+
 func TestNewPeer(t *testing.T) {
 	name := "nodename"
 	caps := []Cap{{"foo", 2}, {"bar", 3}}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -714,7 +714,7 @@ running:
 
 				go srv.runPeer(p)
 				if peers[c.id] != nil {
-					peers[c.id].PairPeer = p
+					peers[c.id].SetPairPeer(p)
 					srv.log.Debug("Adding p2p pair peer", "name", name, "addr", c.fd.RemoteAddr(), "connections", connCount)
 				} else {
 					peers[c.id] = p
@@ -777,8 +777,7 @@ func removePeerTracking(peers map[discover.NodeID]*Peer, pd peerDrop, connCount 
 	}
 	if current := peers[pd.ID()]; current == pd.Peer {
 		delete(peers, pd.ID())
-	} else if current != nil && current.PairPeer == pd.Peer {
-		current.PairPeer = nil
+	} else if current != nil && current.ClearPairPeer(pd.Peer) {
 	}
 	return connCount
 }
@@ -801,7 +800,7 @@ func (srv *Server) encHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCo
 		return DiscTooManyPeers
 	case peers[c.id] != nil:
 		exitPeer := peers[c.id]
-		if exitPeer.PairPeer != nil {
+		if exitPeer.PairPeer() != nil {
 			return DiscAlreadyConnected
 		}
 		return nil

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -490,7 +490,7 @@ func TestRemovePeerTrackingKeepsPrimaryOnPairDrop(t *testing.T) {
 	id := randomID()
 	primary := newPeer(&conn{id: id}, nil)
 	pair := newPeer(&conn{id: id}, nil)
-	primary.PairPeer = pair
+	primary.SetPairPeer(pair)
 
 	peers := map[discover.NodeID]*Peer{id: primary}
 	connCount := removePeerTracking(peers, peerDrop{Peer: pair}, 2)
@@ -501,7 +501,7 @@ func TestRemovePeerTrackingKeepsPrimaryOnPairDrop(t *testing.T) {
 	if peers[id] != primary {
 		t.Fatal("primary peer was removed while dropping pair peer")
 	}
-	if primary.PairPeer != nil {
+	if primary.PairPeer() != nil {
 		t.Fatal("primary peer still references dropped pair peer")
 	}
 }


### PR DESCRIPTION
# Proposed changes

Guard PairPeer access with synchronized helpers and snapshot the pair before launching async disconnect during peer shutdown.

Add regression coverage for pair-peer teardown and keep the existing pair tracking checks using the synchronized accessors.

fix panic:

```text
WARN [04-21|13:49:14.217] Failed to unregister sync peer           peer=f14274f155d8b9fd err="peer is not registered"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0xbf65d6]

goroutine 79891 [running]:
github.com/XinFinOrg/XDPoSChain/p2p.(*Peer).Disconnect(...)
        github.com/XinFinOrg/XDPoSChain/p2p/peer.go:159
github.com/XinFinOrg/XDPoSChain/p2p.(*Peer).run.func2()
        github.com/XinFinOrg/XDPoSChain/p2p/peer.go:239 +0x16
created by github.com/XinFinOrg/XDPoSChain/p2p.(*Peer).run in goroutine 79878
        github.com/XinFinOrg/XDPoSChain/p2p/peer.go:239 +0x3c5
```


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
