### PR TITLE
feat(internal/ethapi): implement EIP-7910 - add XDPoS_getConfig

### DIFF
--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -16,6 +16,7 @@
 package XDPoS
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -33,6 +34,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/params/chainconfigview"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
 )
@@ -120,6 +122,26 @@ const (
 )
 
 type MessageStatus map[string]map[string]SignerTypes
+
+type configBackend struct {
+	chain consensus.ChainReader
+}
+
+func (b configBackend) GenesisHeader(_ context.Context) (*types.Header, error) {
+	header := b.chain.GetHeaderByNumber(0)
+	if header == nil {
+		return nil, errors.New("genesis header not found")
+	}
+	return header, nil
+}
+
+func (b configBackend) CurrentHeader() *types.Header {
+	return b.chain.CurrentHeader()
+}
+
+func (b configBackend) ChainConfig() *params.ChainConfig {
+	return b.chain.Config()
+}
 
 // GetSnapshot retrieves the state snapshot at a given block.
 func (api *API) GetSnapshot(number *rpc.BlockNumber) (*utils.PublicApiSnapshot, error) {
@@ -347,6 +369,11 @@ func (api *API) NetworkInformation() NetworkInformation {
 	info.ConsensusConfigs = *api.XDPoS.config
 
 	return info
+}
+
+// Config returns the current and scheduled chain configuration view.
+func (api *API) Config(ctx context.Context) (*chainconfigview.ConfigResponse, error) {
+	return chainconfigview.Build(ctx, configBackend{chain: api.chain})
 }
 
 /*

--- a/consensus/XDPoS/api_test.go
+++ b/consensus/XDPoS/api_test.go
@@ -1,16 +1,107 @@
+// Copyright (c) 2026 XDPoSChain
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 package XDPoS
 
 import (
+	"context"
 	"encoding/json"
 	"math/big"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
+	"github.com/XinFinOrg/XDPoSChain/core/forkid"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/params/forks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type configChainMock struct {
+	genesis *types.Header
+	current *types.Header
+	config  *params.ChainConfig
+}
+
+func newConfigChainMockWithCurrent(current uint64) *configChainMock {
+	return &configChainMock{
+		genesis: &types.Header{Number: big.NewInt(0)},
+		current: &types.Header{Number: new(big.Int).SetUint64(current)},
+		config: &params.ChainConfig{
+			ChainID:             big.NewInt(42),
+			HomesteadBlock:      big.NewInt(0),
+			DAOForkSupport:      true,
+			EIP150Block:         big.NewInt(0),
+			EIP155Block:         big.NewInt(0),
+			EIP158Block:         big.NewInt(0),
+			ByzantiumBlock:      big.NewInt(0),
+			ConstantinopleBlock: big.NewInt(0),
+			PetersburgBlock:     big.NewInt(0),
+			IstanbulBlock:       big.NewInt(0),
+			BerlinBlock:         big.NewInt(0),
+			EIP1559Block:        big.NewInt(1000),
+			XDPoS:               &params.XDPoSConfig{V2: &params.V2{SwitchBlock: big.NewInt(1500)}},
+		},
+	}
+}
+
+func (m *configChainMock) Config() *params.ChainConfig { return m.config }
+
+func (m *configChainMock) CurrentHeader() *types.Header { return m.current }
+
+func (m *configChainMock) GetHeader(hash common.Hash, number uint64) *types.Header {
+	header := m.GetHeaderByNumber(number)
+	if header != nil && header.Hash() == hash {
+		return header
+	}
+	return nil
+}
+
+func (m *configChainMock) GetHeaderByNumber(number uint64) *types.Header {
+	switch number {
+	case 0:
+		return m.genesis
+	case m.current.Number.Uint64():
+		return m.current
+	default:
+		return nil
+	}
+}
+
+func (m *configChainMock) GetHeaderByHash(hash common.Hash) *types.Header {
+	if m.genesis.Hash() == hash {
+		return m.genesis
+	}
+	if m.current.Hash() == hash {
+		return m.current
+	}
+	return nil
+}
+
+func (m *configChainMock) GetBlock(hash common.Hash, number uint64) *types.Block {
+	header := m.GetHeader(hash, number)
+	if header == nil {
+		return nil
+	}
+	return types.NewBlockWithHeader(header)
+}
+
+var _ consensus.ChainReader = (*configChainMock)(nil)
 
 func TestCalculateSignersVote(t *testing.T) {
 	info := make(map[string]SignerTypes)
@@ -165,4 +256,53 @@ func TestJsonNumberToBigInt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPIGetConfig(t *testing.T) {
+	chain := newConfigChainMockWithCurrent(1500)
+	api := &API{chain: chain}
+
+	resp, err := api.Config(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Current)
+	require.Equal(t, uint64(1500), resp.Current.ActivationBlock)
+	require.Contains(t, resp.Current.ActiveForks, forks.XDPoSV2.String())
+	require.Nil(t, resp.Next)
+	require.Nil(t, resp.Last)
+	require.Equal(t, chain.config.ChainID, (*big.Int)(resp.Current.ChainId))
+	forkID := forkid.NewID(chain.config, types.NewBlockWithHeader(chain.genesis), resp.Current.ActivationBlock).Hash
+	require.Equal(t, forkID[:], []byte(resp.Current.ForkId))
+	require.NotNil(t, configBackend{chain: chain}.CurrentHeader())
+	genesis, err := configBackend{chain: chain}.GenesisHeader(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, genesis)
+}
+
+func TestConfigBackendGenesisHeaderReturnsErrorWhenMissing(t *testing.T) {
+	chain := newConfigChainMockWithCurrent(1500)
+	chain.genesis = nil
+
+	genesis, err := configBackend{chain: chain}.GenesisHeader(context.Background())
+	require.Error(t, err)
+	require.Nil(t, genesis)
+}
+
+func TestAPIGetConfig_BeforeXDPoSV2Switch(t *testing.T) {
+	chain := newConfigChainMockWithCurrent(1400)
+	api := &API{chain: chain}
+
+	resp, err := api.Config(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Current)
+	require.NotNil(t, resp.Next)
+	require.NotNil(t, resp.Last)
+
+	require.Equal(t, uint64(1000), resp.Current.ActivationBlock)
+	require.NotContains(t, resp.Current.ActiveForks, forks.XDPoSV2.String())
+
+	require.Equal(t, uint64(1500), resp.Next.ActivationBlock)
+	require.Contains(t, resp.Next.ActiveForks, forks.XDPoSV2.String())
+	require.Equal(t, uint64(1500), resp.Last.ActivationBlock)
 }

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -1,0 +1,65 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package forkid implements EIP-2124 (https://eips.ethereum.org/EIPS/eip-2124).
+package forkid
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+// ID is a fork identifier as defined by EIP-2124.
+type ID struct {
+	Hash [4]byte // CRC32 checksum of the genesis block and passed fork block numbers
+	Next uint64  // Block number of the next upcoming fork, or 0 if no forks are known
+}
+
+// NewID calculates the XDC fork ID from the chain config, genesis hash, head.
+func NewID(config *params.ChainConfig, genesis *types.Block, head uint64) ID {
+	// Calculate the starting checksum from the genesis hash
+	hash := crc32.ChecksumIEEE(genesis.Hash().Bytes())
+
+	// Calculate the current fork checksum and the next fork block
+	forksByBlock := config.GatherForks()
+	for _, fork := range forksByBlock {
+		if fork <= head {
+			// Fork already passed, checksum the previous hash and the fork number
+			hash = checksumUpdate(hash, fork)
+			continue
+		}
+		return ID{Hash: checksumToBytes(hash), Next: fork}
+	}
+	return ID{Hash: checksumToBytes(hash), Next: 0}
+}
+
+// checksumUpdate calculates the next IEEE CRC32 checksum based on the previous
+// one and a fork block number (equivalent to CRC32(original-blob || fork)).
+func checksumUpdate(hash uint32, fork uint64) uint32 {
+	var blob [8]byte
+	binary.BigEndian.PutUint64(blob[:], fork)
+	return crc32.Update(hash, crc32.IEEETable, blob[:])
+}
+
+// checksumToBytes converts a uint32 checksum into a [4]byte array.
+func checksumToBytes(hash uint32) [4]byte {
+	var blob [4]byte
+	binary.BigEndian.PutUint32(blob[:], hash)
+	return blob
+}

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -1,0 +1,105 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package forkid
+
+import (
+	"hash/crc32"
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewID(t *testing.T) {
+	genesis := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
+	config := &params.ChainConfig{
+		BerlinBlock:  big.NewInt(1000),
+		EIP1559Block: big.NewInt(1000),
+		XDPoS: &params.XDPoSConfig{V2: &params.V2{
+			SwitchBlock: big.NewInt(1500),
+		}},
+	}
+
+	genesisChecksum := crc32.ChecksumIEEE(genesis.Hash().Bytes())
+	after1000 := checksumUpdate(genesisChecksum, 1000)
+	after1500 := checksumUpdate(after1000, 1500)
+
+	tests := []struct {
+		name string
+		head uint64
+		want ID
+	}{
+		{
+			name: "before first fork",
+			head: 999,
+			want: ID{Hash: checksumToBytes(genesisChecksum), Next: 1000},
+		},
+		// Duplicate fork heights are deduplicated by GatherForks; this case asserts
+		// that NewID observes the deduplicated list returned by the chain config.
+		{
+			name: "at duplicated block fork only updates once",
+			head: 1000,
+			want: ID{Hash: checksumToBytes(after1000), Next: 1500},
+		},
+		{
+			name: "before xdpos v2 switch keeps next boundary",
+			head: 1499,
+			want: ID{Hash: checksumToBytes(after1000), Next: 1500},
+		},
+		{
+			name: "at xdpos v2 switch consumes final fork",
+			head: 1500,
+			want: ID{Hash: checksumToBytes(after1500), Next: 0},
+		},
+		{
+			name: "after all forks stays final",
+			head: 2000,
+			want: ID{Hash: checksumToBytes(after1500), Next: 0},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, NewID(config, genesis, test.head))
+		})
+	}
+}
+
+func TestNewIDWithoutForks(t *testing.T) {
+	genesis := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
+	checksum := crc32.ChecksumIEEE(genesis.Hash().Bytes())
+
+	assert.Equal(t, ID{Hash: checksumToBytes(checksum), Next: 0}, NewID(&params.ChainConfig{}, genesis, 0))
+}
+
+func TestNewIDIncludesDAOForkBlockInChecksum(t *testing.T) {
+	genesis := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
+	config := &params.ChainConfig{
+		HomesteadBlock: big.NewInt(0),
+		DAOForkBlock:   big.NewInt(5),
+		EIP150Block:    big.NewInt(9),
+	}
+
+	genesisChecksum := crc32.ChecksumIEEE(genesis.Hash().Bytes())
+	afterDAO := checksumUpdate(genesisChecksum, 5)
+	afterEIP150 := checksumUpdate(afterDAO, 9)
+
+	assert.Equal(t, ID{Hash: checksumToBytes(afterDAO), Next: 9}, NewID(config, genesis, 5))
+	assert.Equal(t, ID{Hash: checksumToBytes(afterEIP150), Next: 0}, NewID(config, genesis, 9))
+}

--- a/core/vm/XDCx_price.go
+++ b/core/vm/XDCx_price.go
@@ -44,6 +44,10 @@ func (t *XDCxLastPrice) SetTradingState(tradingStateDB *tradingstate.TradingStat
 	}
 }
 
+func (c *XDCxLastPrice) Name() string {
+	return "XDCX_LAST_PRICE"
+}
+
 func (t *XDCxEpochPrice) RequiredGas(input []byte) uint64 {
 	return params.XDCXPriceGas
 }
@@ -68,4 +72,8 @@ func (t *XDCxEpochPrice) SetTradingState(tradingStateDB *tradingstate.TradingSta
 	} else {
 		t.tradingStateDB = nil
 	}
+}
+
+func (c *XDCxEpochPrice) Name() string {
+	return "XDCX_EPOCH_PRICE"
 }

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -41,6 +41,7 @@ import (
 type PrecompiledContract interface {
 	RequiredGas(input []byte) uint64  // RequiredPrice calculates the contract gas use
 	Run(input []byte) ([]byte, error) // Run runs the precompiled contract
+	Name() string
 }
 
 // PrecompiledContracts contains the precompiled contracts supported at the given fork.
@@ -269,6 +270,10 @@ func (c *ecrecover) Run(input []byte) ([]byte, error) {
 	return common.LeftPadBytes(crypto.Keccak256(pubKey[1:])[12:], 32), nil
 }
 
+func (c *ecrecover) Name() string {
+	return "ECREC"
+}
+
 // SHA256 implemented as a native contract.
 type sha256hash struct{}
 
@@ -282,6 +287,10 @@ func (c *sha256hash) RequiredGas(input []byte) uint64 {
 func (c *sha256hash) Run(input []byte) ([]byte, error) {
 	h := sha256.Sum256(input)
 	return h[:], nil
+}
+
+func (c *sha256hash) Name() string {
+	return "SHA256"
 }
 
 // RIPEMD160 implemented as a native contract.
@@ -300,6 +309,10 @@ func (c *ripemd160hash) Run(input []byte) ([]byte, error) {
 	return common.LeftPadBytes(ripemd.Sum(nil), 32), nil
 }
 
+func (c *ripemd160hash) Name() string {
+	return "RIPEMD160"
+}
+
 // data copy implemented as a native contract.
 type dataCopy struct{}
 
@@ -312,6 +325,10 @@ func (c *dataCopy) RequiredGas(input []byte) uint64 {
 }
 func (c *dataCopy) Run(in []byte) ([]byte, error) {
 	return common.CopyBytes(in), nil
+}
+
+func (c *dataCopy) Name() string {
+	return "ID"
 }
 
 // bigModExp implements a native big integer exponential modular operation.
@@ -504,6 +521,10 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	return common.LeftPadBytes(v, int(modLen)), nil
 }
 
+func (c *bigModExp) Name() string {
+	return "MODEXP"
+}
+
 // newCurvePoint unmarshals a binary blob into a bn256 elliptic curve point,
 // returning it, or an error if the point is invalid.
 func newCurvePoint(blob []byte) (*bn256.G1, error) {
@@ -540,6 +561,10 @@ func runBn256Add(input []byte) ([]byte, error) {
 	return res.Marshal(), nil
 }
 
+// Fork-specific bn256 precompiles intentionally share the same operation names.
+// The active implementation is still selected by address from the fork-specific
+// precompile map, so identical Name values across hard forks are expected.
+
 // bn256AddIstanbul implements a native elliptic curve point addition conforming to
 // Istanbul consensus rules.
 type bn256AddIstanbul struct{}
@@ -553,6 +578,10 @@ func (c *bn256AddIstanbul) Run(input []byte) ([]byte, error) {
 	return runBn256Add(input)
 }
 
+func (c *bn256AddIstanbul) Name() string {
+	return "BN256_ADD"
+}
+
 // bn256AddByzantium implements a native elliptic curve point addition
 // conforming to Byzantium consensus rules.
 type bn256AddByzantium struct{}
@@ -564,6 +593,10 @@ func (c *bn256AddByzantium) RequiredGas(input []byte) uint64 {
 
 func (c *bn256AddByzantium) Run(input []byte) ([]byte, error) {
 	return runBn256Add(input)
+}
+
+func (c *bn256AddByzantium) Name() string {
+	return "BN256_ADD"
 }
 
 // runBn256ScalarMul implements the Bn256ScalarMul precompile, referenced by
@@ -591,6 +624,10 @@ func (c *bn256ScalarMulIstanbul) Run(input []byte) ([]byte, error) {
 	return runBn256ScalarMul(input)
 }
 
+func (c *bn256ScalarMulIstanbul) Name() string {
+	return "BN256_MUL"
+}
+
 // bn256ScalarMulByzantium implements a native elliptic curve scalar
 // multiplication conforming to Byzantium consensus rules.
 type bn256ScalarMulByzantium struct{}
@@ -602,6 +639,10 @@ func (c *bn256ScalarMulByzantium) RequiredGas(input []byte) uint64 {
 
 func (c *bn256ScalarMulByzantium) Run(input []byte) ([]byte, error) {
 	return runBn256ScalarMul(input)
+}
+
+func (c *bn256ScalarMulByzantium) Name() string {
+	return "BN256_MUL"
 }
 
 var (
@@ -647,15 +688,9 @@ func runBn256Pairing(input []byte) ([]byte, error) {
 }
 
 type ringSignatureVerifier struct{}
-type bulletproofVerifier struct{}
-
-func (c *bulletproofVerifier) RequiredGas(input []byte) uint64 {
-	//the gas should depends on the ringsize
-	return 100000
-}
 
 func (c *ringSignatureVerifier) RequiredGas(input []byte) uint64 {
-	//the gas should depends on the ringsize
+	// Ring signature verification currently uses a fixed gas charge.
 	return 100000
 }
 
@@ -668,6 +703,21 @@ func (c *ringSignatureVerifier) Run(proof []byte) ([]byte, error) {
 		return []byte{}, errors.New("fail to verify ring signature")
 	}
 	return []byte{}, nil
+}
+
+func (c *ringSignatureVerifier) Name() string {
+	return "RING_SIG_VERIFY"
+}
+
+type bulletproofVerifier struct{}
+
+func (c *bulletproofVerifier) RequiredGas(input []byte) uint64 {
+	// Bulletproof verification currently uses a fixed gas charge.
+	return 100000
+}
+
+func (c *bulletproofVerifier) Name() string {
+	return "BULLET_PROOF_VERIFY"
 }
 
 func (c *bulletproofVerifier) Run(proof []byte) ([]byte, error) {
@@ -695,6 +745,10 @@ func (c *bn256PairingIstanbul) Run(input []byte) ([]byte, error) {
 	return runBn256Pairing(input)
 }
 
+func (c *bn256PairingIstanbul) Name() string {
+	return "BN256_PAIRING"
+}
+
 // bn256PairingByzantium implements a pairing pre-compile for the bn256 curve
 // conforming to Byzantium consensus rules.
 type bn256PairingByzantium struct{}
@@ -708,6 +762,10 @@ func (c *bn256PairingByzantium) Run(input []byte) ([]byte, error) {
 	return runBn256Pairing(input)
 }
 
+func (c *bn256PairingByzantium) Name() string {
+	return "BN256_PAIRING"
+}
+
 type blake2F struct{}
 
 func (c *blake2F) RequiredGas(input []byte) uint64 {
@@ -717,6 +775,10 @@ func (c *blake2F) RequiredGas(input []byte) uint64 {
 		return 0
 	}
 	return uint64(binary.BigEndian.Uint32(input[0:4]))
+}
+
+func (c *blake2F) Name() string {
+	return "BLAKE2F"
 }
 
 const (

--- a/docs/xdc/XDPoS/XDPoS.md
+++ b/docs/xdc/XDPoS/XDPoS.md
@@ -1,5 +1,114 @@
-
 # Module XDPoS
+
+## Method XDPoS_config
+
+The `config` method returns chain-configuration snapshots for the current fork boundary, the next scheduled fork boundary, and the last known future fork boundary.
+
+This method is an XDPoS-specific extension. It is inspired by `eth_config` / EIP-7910, but it does not strictly match geth.
+
+Compatibility notes:
+
+- XDPoS returns `activationBlock` for each config entry.
+- geth uses `activationTime` for time-based fork scheduling.
+- XDPoS does not currently implement `blobSchedule`. XDC does not support blob transactions, so this field is intentionally omitted from `XDPoS_config` responses.
+- XDPoS currently selects `current`, `next`, and `last` using block-based fork activation metadata.
+- XDPoS may include chain-specific precompiles and system contracts that do not exist on Ethereum mainnet.
+- Each config entry is a snapshot evaluated at `activationBlock`. Lists such as `systemContracts` describe what is active at that block; they do not imply that every listed item has its own dedicated activation block.
+
+Parameters:
+
+None
+
+Returns:
+
+result: object configResponse
+
+- current: object config, the snapshot active at the current fork boundary.
+- next: object config, the snapshot that will become active at the next scheduled fork boundary, or `null` if no future fork is known.
+- last: object config, the snapshot for the last known future fork boundary, or `null` if no future fork is known.
+
+Config object fields:
+
+- activationBlock: uint64, the block height used to anchor this configuration snapshot.
+- chainId: big.Int, the configured chain ID represented as a hexadecimal string.
+- forkId: hex-encoded bytes string, the fork identifier derived from the configured fork schedule (for example, `"0x4f9a9c51"`).
+- activeForks: array of string, the modeled forks active at this `activationBlock`. Values use the RPC's fork labels as returned by `forks.Fork.String()` (for example, `"EIP1559"`, `"Prague"`, `"Cancun"`).
+- precompiles: object, a map of active precompile names to contract addresses.
+- systemContracts: object, a map of system contract names to contract addresses that are active at this `activationBlock` snapshot.
+
+`blobSchedule` from EIP-7910 is not implemented and is therefore omitted from the response.
+
+Example:
+
+```shell
+curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
+  "jsonrpc": "2.0",
+  "id": 1001,
+  "method": "XDPoS_config"
+}' | jq
+```
+
+Response:
+
+The example below is illustrative. Actual fork IDs, precompiles, and system contracts depend on the chain configuration active on the node.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1001,
+  "result": {
+    "current": {
+      "activationBlock": 1000,
+      "chainId": "0x32",
+      "forkId": "0x4f9a9c51",
+      "activeForks": [
+        "EIP1559",
+        "Prague"
+      ],
+      "precompiles": {
+        "ECREC": "0x0000000000000000000000000000000000000001",
+        "SHA256": "0x0000000000000000000000000000000000000002",
+        "BLAKE2F": "0x0000000000000000000000000000000000000009"
+      },
+      "systemContracts": {
+        "HISTORY_STORAGE_ADDRESS": "0x0000F90827F1C53a10cb7A02335B175320002935"
+      }
+    },
+    "next": {
+      "activationBlock": 2000,
+      "chainId": "0x32",
+      "forkId": "0xd0c4b3b7",
+      "activeForks": [
+        "Cancun"
+      ],
+      "precompiles": {
+        "ECREC": "0x0000000000000000000000000000000000000001",
+        "SHA256": "0x0000000000000000000000000000000000000002",
+        "BLAKE2F": "0x0000000000000000000000000000000000000009"
+      },
+      "systemContracts": {
+        "HISTORY_STORAGE_ADDRESS": "0x0000F90827F1C53a10cb7A02335B175320002935"
+      }
+    },
+    "last": {
+      "activationBlock": 3000,
+      "chainId": "0x32",
+      "forkId": "0x6b495dfd",
+      "activeForks": [
+        "Osaka"
+      ],
+      "precompiles": {
+        "ECREC": "0x0000000000000000000000000000000000000001",
+        "SHA256": "0x0000000000000000000000000000000000000002",
+        "BLAKE2F": "0x0000000000000000000000000000000000000009"
+      },
+      "systemContracts": {
+        "HISTORY_STORAGE_ADDRESS": "0x0000F90827F1C53a10cb7A02335B175320002935"
+      }
+    }
+  }
+}
+```
 
 ## Method XDPoS_getBlockInfoByEpochNum
 

--- a/internal/ethapi/override/override_test.go
+++ b/internal/ethapi/override/override_test.go
@@ -33,6 +33,10 @@ func (p *precompileContract) RequiredGas(input []byte) uint64 { return 0 }
 
 func (p *precompileContract) Run(input []byte) ([]byte, error) { return nil, nil }
 
+func (p *precompileContract) Name() string {
+	return "test-implement"
+}
+
 func TestStateOverrideMovePrecompile(t *testing.T) {
 	db := state.NewDatabase(rawdb.NewMemoryDatabase())
 	statedb, err := state.New(common.Hash{}, db)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -142,6 +142,11 @@ web3._extend({
 			params: 3,
 			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter, web3._extend.formatters.inputBlockNumberFormatter]
 		}),
+		new web3._extend.Method({
+			name: 'config',
+			call: 'XDPoS_config',
+			params: 0,
+		})
 	],
 	properties: [
 		new web3._extend.Property({

--- a/params/chainconfigview/view.go
+++ b/params/chainconfigview/view.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 XDPoSChain
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package chainconfigview
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"slices"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
+	"github.com/XinFinOrg/XDPoSChain/core/forkid"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+// Backend provides the chain state required to build the config RPC response.
+type Backend interface {
+	GenesisHeader(ctx context.Context) (*types.Header, error)
+	CurrentHeader() *types.Header
+	ChainConfig() *params.ChainConfig
+}
+
+// ConfigEntry describes the chain-configuration snapshot evaluated at a
+// specific block. ActivationBlock anchors the snapshot; fields such as
+// SystemContracts list what is active at that block and do not imply that each
+// individual item activates exactly at that block.
+type ConfigEntry struct {
+	ActivationBlock uint64                    `json:"activationBlock"`
+	ChainId         *hexutil.Big              `json:"chainId"`
+	ForkId          hexutil.Bytes             `json:"forkId"`
+	ActiveForks     []string                  `json:"activeForks"`
+	Precompiles     map[string]common.Address `json:"precompiles"`
+	SystemContracts map[string]common.Address `json:"systemContracts"`
+}
+
+// ConfigResponse groups the current, next, and trailing scheduled configs.
+type ConfigResponse struct {
+	Current *ConfigEntry `json:"current"`
+	Next    *ConfigEntry `json:"next"`
+	Last    *ConfigEntry `json:"last"`
+}
+
+// Build assembles the chain configuration view for the config RPC.
+//
+// The returned ConfigResponse always sets Current to the config snapshot active
+// at the current head. Next is the next scheduled config-transition boundary
+// after the current head, if one exists. Last is the trailing scheduled
+// transition described by EIP-7910, and is omitted when there is no future
+// transition to report:
+// https://eips.ethereum.org/EIPS/eip-7910.
+func Build(ctx context.Context, backend Backend) (*ConfigResponse, error) {
+	genesis, err := backend.GenesisHeader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load genesis: %w", err)
+	}
+	if genesis == nil {
+		return nil, fmt.Errorf("unable to load genesis: nil header")
+	}
+
+	current := backend.CurrentHeader()
+	if current == nil {
+		return nil, fmt.Errorf("unable to load current header: nil header")
+	}
+	if current.Number == nil {
+		return nil, fmt.Errorf("unable to load current header: nil number")
+	}
+	cfg := backend.ChainConfig()
+	if cfg == nil {
+		return nil, fmt.Errorf("unable to load chain config: nil config")
+	}
+	if cfg.ChainID == nil {
+		return nil, fmt.Errorf("unable to load chain config: nil chain ID")
+	}
+	genesisBlock := types.NewBlockWithHeader(genesis)
+
+	currentBlock, nextBlock, lastBlock := configBlocks(cfg, current.Number.Uint64())
+	resp := ConfigResponse{
+		Current: assembleConfig(cfg, genesisBlock, currentBlock),
+		Next:    assembleConfig(cfg, genesisBlock, nextBlock),
+		Last:    assembleConfig(cfg, genesisBlock, lastBlock),
+	}
+	return &resp, nil
+}
+
+func configBlocks(cfg *params.ChainConfig, head uint64) (*big.Int, *big.Int, *big.Int) {
+	forkBlocks := cfg.GatherForks()
+	if len(forkBlocks) == 0 {
+		return new(big.Int), nil, nil
+	}
+	idx, found := slices.BinarySearch(forkBlocks, head)
+	if found {
+		idx++
+	}
+
+	current := new(big.Int)
+	if idx > 0 {
+		current.SetUint64(forkBlocks[idx-1])
+	}
+
+	var next *big.Int
+	if idx < len(forkBlocks) {
+		next = new(big.Int).SetUint64(forkBlocks[idx])
+	}
+	if next == nil {
+		return current, nil, nil
+	}
+
+	last := new(big.Int).SetUint64(forkBlocks[len(forkBlocks)-1])
+	return current, next, last
+}
+
+func assembleConfig(cfg *params.ChainConfig, genesis *types.Block, num *big.Int) *ConfigEntry {
+	if num == nil {
+		return nil
+	}
+
+	rules := cfg.Rules(num)
+	contracts := vm.ActivePrecompiledContracts(rules)
+	precompiles := make(map[string]common.Address, len(contracts))
+	for addr, precompile := range contracts {
+		precompiles[precompile.Name()] = addr
+	}
+	block := num.Uint64()
+	id := forkid.NewID(cfg, genesis, block).Hash
+	return &ConfigEntry{
+		ActivationBlock: block,
+		ChainId:         (*hexutil.Big)(cfg.ChainID),
+		ForkId:          id[:],
+		ActiveForks:     cfg.ActiveForks(num),
+		Precompiles:     precompiles,
+		SystemContracts: cfg.ActiveSystemContracts(block),
+	}
+}

--- a/params/chainconfigview/view_test.go
+++ b/params/chainconfigview/view_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 XDPoSChain
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package chainconfigview
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
+	"github.com/XinFinOrg/XDPoSChain/core/forkid"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+type stubBackend struct {
+	genesis *types.Header
+	current *types.Header
+	cfg     *params.ChainConfig
+}
+
+func (b stubBackend) GenesisHeader(context.Context) (*types.Header, error) { return b.genesis, nil }
+func (b stubBackend) CurrentHeader() *types.Header                         { return b.current }
+func (b stubBackend) ChainConfig() *params.ChainConfig                     { return b.cfg }
+
+func TestConfigBlocksSingleForkAfterHead(t *testing.T) {
+	cfg := &params.ChainConfig{
+		BerlinBlock: big.NewInt(1000),
+	}
+
+	current, next, last := configBlocks(cfg, 2000)
+	if current == nil || current.Uint64() != 1000 {
+		t.Fatalf("current = %v, want 1000", current)
+	}
+	if next != nil {
+		t.Fatalf("next = %v, want nil", next)
+	}
+	if last != nil {
+		t.Fatalf("last = %v, want nil", last)
+	}
+}
+
+func TestConfigBlocksHeadBeyondAllForks(t *testing.T) {
+	cfg := &params.ChainConfig{
+		BerlinBlock:  big.NewInt(1000),
+		EIP1559Block: big.NewInt(2000),
+	}
+
+	current, next, last := configBlocks(cfg, 3000)
+	if current == nil || current.Uint64() != 2000 {
+		t.Fatalf("current = %v, want 2000", current)
+	}
+	if next != nil {
+		t.Fatalf("next = %v, want nil", next)
+	}
+	if last != nil {
+		t.Fatalf("last = %v, want nil", last)
+	}
+}
+
+func TestConfigBlocksWithFutureTransitionKeepsLast(t *testing.T) {
+	cfg := &params.ChainConfig{
+		BerlinBlock: big.NewInt(1000),
+		LondonBlock: big.NewInt(2000),
+		MergeBlock:  big.NewInt(3000),
+	}
+
+	current, next, last := configBlocks(cfg, 1500)
+	if current == nil || current.Uint64() != 1000 {
+		t.Fatalf("current = %v, want 1000", current)
+	}
+	if next == nil || next.Uint64() != 2000 {
+		t.Fatalf("next = %v, want 2000", next)
+	}
+	if last == nil || last.Uint64() != 3000 {
+		t.Fatalf("last = %v, want 3000", last)
+	}
+}
+
+func TestBuildHeadBeyondAllForksOmitsNextAndLast(t *testing.T) {
+	cfg := &params.ChainConfig{
+		ChainID:      big.NewInt(51),
+		BerlinBlock:  big.NewInt(1000),
+		EIP1559Block: big.NewInt(2000),
+		Ethash:       new(params.EthashConfig),
+	}
+
+	resp, err := Build(context.Background(), stubBackend{
+		genesis: &types.Header{Number: big.NewInt(0)},
+		current: &types.Header{Number: big.NewInt(3000)},
+		cfg:     cfg,
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if resp.Current == nil || resp.Current.ActivationBlock != 2000 {
+		t.Fatalf("current = %+v, want activation block 2000", resp.Current)
+	}
+	if resp.Next != nil {
+		t.Fatalf("next = %v, want nil", resp.Next)
+	}
+	if resp.Last != nil {
+		t.Fatalf("last = %v, want nil", resp.Last)
+	}
+}
+
+func TestBuildWithoutScheduledForks(t *testing.T) {
+	cfg := &params.ChainConfig{
+		ChainID: big.NewInt(51),
+		Ethash:  new(params.EthashConfig),
+	}
+
+	resp, err := Build(context.Background(), stubBackend{
+		genesis: &types.Header{Number: big.NewInt(0)},
+		current: &types.Header{Number: big.NewInt(25)},
+		cfg:     cfg,
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if resp.Current == nil {
+		t.Fatal("current = nil, want genesis config")
+	}
+	if resp.Current.ActivationBlock != 0 {
+		t.Fatalf("current activation block = %d, want 0", resp.Current.ActivationBlock)
+	}
+	if resp.Next != nil {
+		t.Fatalf("next = %v, want nil", resp.Next)
+	}
+	if resp.Last != nil {
+		t.Fatalf("last = %v, want nil", resp.Last)
+	}
+}
+
+func BenchmarkAssembleConfig(b *testing.B) {
+	cfg := params.TestnetChainConfig.Clone()
+	genesis := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
+	num := big.NewInt(90_000_000)
+
+	b.Run("current", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = assembleConfig(cfg, genesis, num)
+		}
+	})
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = assembleConfigLegacy(cfg, genesis, num)
+		}
+	})
+}
+
+func assembleConfigLegacy(cfg *params.ChainConfig, genesis *types.Block, num *big.Int) *ConfigEntry {
+	if num == nil {
+		return nil
+	}
+
+	rules := cfg.Rules(num)
+	precompiles := make(map[string]common.Address)
+	for addr, precompile := range vm.ActivePrecompiledContracts(rules) {
+		precompiles[precompile.Name()] = addr
+	}
+	block := num.Uint64()
+	id := forkid.NewID(cfg, genesis, block).Hash
+	return &ConfigEntry{
+		ActivationBlock: block,
+		ChainId:         (*hexutil.Big)(cfg.ChainID),
+		ForkId:          id[:],
+		ActiveForks:     cfg.ActiveForks(num),
+		Precompiles:     precompiles,
+		SystemContracts: cfg.ActiveSystemContracts(block),
+	}
+}

--- a/params/config.go
+++ b/params/config.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 )
@@ -810,4 +811,189 @@ func (c *ChainConfig) Description() string {
 	banner += fmt.Sprintf("  - LendingRegistrationSMC:      %-8s\n", c.LendingRegistrationSMC)
 	banner += fmt.Sprintf("  - Engine:                      %v", engine)
 	return banner
+}
+
+// GatherForks gathers all the known forks and creates a sorted list of
+// block number based forks.
+func (c *ChainConfig) GatherForks() []uint64 {
+	forksByBlock := make([]uint64, 0, len(chainConfigForkBlockFields)+1)
+	ForEachChainConfigForkBlock(c, func(_ string, block *big.Int) {
+		if block != nil {
+			forksByBlock = append(forksByBlock, block.Uint64())
+		}
+	})
+	// Nested fork switches are not discoverable by the reflection pass above and
+	// must be appended manually when introduced.
+	if c.XDPoS != nil && c.XDPoS.V2 != nil && c.XDPoS.V2.SwitchBlock != nil {
+		forksByBlock = append(forksByBlock, c.XDPoS.V2.SwitchBlock.Uint64())
+	}
+	slices.Sort(forksByBlock)
+
+	// Deduplicate fork identifiers applying multiple forks
+	forksByBlock = slices.Compact(forksByBlock)
+	// Skip any forks in block 0, that's the genesis ruleset
+	if len(forksByBlock) > 0 && forksByBlock[0] == 0 {
+		forksByBlock = forksByBlock[1:]
+	}
+	return forksByBlock
+}
+
+// ActiveForks returns the list of active forks at the given block height.
+// The returned list is sorted in alphabetical order.
+func (c *ChainConfig) ActiveForks(block *big.Int) []string {
+	activeForks := make([]string, 0, 36)
+	if c.IsBerlin(block) {
+		activeForks = append(activeForks, "Berlin")
+	}
+	if c.IsByzantium(block) {
+		activeForks = append(activeForks, "Byzantium")
+	}
+	if c.IsCancun(block) {
+		activeForks = append(activeForks, "Cancun")
+	}
+	if c.IsConstantinople(block) {
+		activeForks = append(activeForks, "Constantinople")
+	}
+	if c.IsDAOFork(block) {
+		activeForks = append(activeForks, "DAO")
+	}
+	if c.IsDenylist(block) {
+		activeForks = append(activeForks, "Denylist")
+	}
+	if c.IsDynamicGasLimit(block) {
+		activeForks = append(activeForks, "DynamicGasLimit")
+	}
+	if c.IsEIP1559(block) {
+		activeForks = append(activeForks, "EIP1559")
+	}
+	if c.IsEIP158(block) {
+		activeForks = append(activeForks, "EIP158")
+	}
+	if c.IsGas50x(block) {
+		activeForks = append(activeForks, "Gas50x")
+	}
+	if c.IsHomestead(block) {
+		activeForks = append(activeForks, "Homestead")
+	}
+	if c.IsIstanbul(block) {
+		activeForks = append(activeForks, "Istanbul")
+	}
+	if c.IsLondon(block) {
+		activeForks = append(activeForks, "London")
+	}
+	if c.IsMerge(block) {
+		activeForks = append(activeForks, "Merge")
+	}
+	if c.IsOsaka(block) {
+		activeForks = append(activeForks, "Osaka")
+	}
+	if c.IsPetersburg(block) {
+		activeForks = append(activeForks, "Petersburg")
+	}
+	if c.IsPrague(block) {
+		activeForks = append(activeForks, "Prague")
+	}
+	if c.IsShanghai(block) {
+		activeForks = append(activeForks, "Shanghai")
+	}
+	if c.IsEIP155(block) {
+		activeForks = append(activeForks, "SpuriousDragon")
+	}
+	if c.IsTIP2019(block) {
+		activeForks = append(activeForks, "TIP2019")
+	}
+	if c.IsTIPIncreaseMasternodes(block) {
+		activeForks = append(activeForks, "TIPIncreaseMasternodes")
+	}
+	if c.IsTIPNoHalvingMNReward(block) {
+		activeForks = append(activeForks, "TIPNoHalvingMNReward")
+	}
+	if c.IsTIPRandomize(block) {
+		activeForks = append(activeForks, "TIPRandomize")
+	}
+	if c.IsTIPSigning(block) {
+		activeForks = append(activeForks, "TIPSigning")
+	}
+	if c.IsTIPTRC21Fee(block) {
+		activeForks = append(activeForks, "TIPTRC21Fee")
+	}
+	if c.IsTIPUpgradePenalty(block) {
+		activeForks = append(activeForks, "TIPUpgradePenalty")
+	}
+	if c.IsTIPUpgradeReward(block) {
+		activeForks = append(activeForks, "TIPUpgradeReward")
+	}
+	if c.IsTIPXDCX(block) {
+		activeForks = append(activeForks, "TIPXDCX")
+	}
+	if c.IsTIPXDCXCancellationFee(block) {
+		activeForks = append(activeForks, "TIPXDCXCancellationFee")
+	}
+	if c.IsTIPXDCXLending(block) {
+		activeForks = append(activeForks, "TIPXDCXLending")
+	}
+	if c.IsTIPXDCXMiner(block) {
+		activeForks = append(activeForks, "TIPXDCXMiner")
+	}
+	if c.IsTIPXDCXReceiver(block) {
+		activeForks = append(activeForks, "TIPXDCXReceiver")
+	}
+	if c.IsEIP150(block) {
+		activeForks = append(activeForks, "TangerineWhistle")
+	}
+	if c.IsTIPEpochHalving(block) {
+		activeForks = append(activeForks, "TIPEpochHalving")
+	}
+	if c.IsXDCxDisable(block) {
+		activeForks = append(activeForks, "XDCxDisable")
+	}
+	if c.IsXDPoSV2(block) {
+		activeForks = append(activeForks, "XDPoSV2")
+	}
+	return activeForks
+}
+
+// ActiveSystemContracts returns the currently active system contracts at the
+// given block height.
+func (c *ChainConfig) ActiveSystemContracts(block uint64) map[string]common.Address {
+	active := make(map[string]common.Address)
+	blockNum := new(big.Int).SetUint64(block)
+	add := func(name string, addr common.Address) {
+		if !addr.IsZero() {
+			active[name] = addr
+		}
+	}
+	// MASTERNODE_VOTING_SMC and BLOCK_SIGNERS are XDPoS-specific and have no
+	// dedicated config address fields. The XDPoS config is the local signal
+	// that this chain actually deploys them, whereas the other entries below
+	// are already gated by their own fork helpers or configured addresses.
+	if c.XDPoS != nil {
+		add("MASTERNODE_VOTING_SMC", common.MasternodeVotingSMCBinary)
+	}
+	if c.XDPoS != nil && !c.IsTIPSigning(blockNum) {
+		add("BLOCK_SIGNERS", common.BlockSignersBinary)
+	}
+	if c.IsTIPRandomize(blockNum) {
+		add("RANDOMIZE_SMC", common.RandomizeSMCBinary)
+	}
+	if c.IsTIPXDCX(blockNum) {
+		add("XDCX_LISTING_SMC", c.XDCXListingSMC)
+		add("RELAYER_REGISTRATION_SMC", c.RelayerRegistrationSMC)
+	}
+	if c.IsTIPXDCXLending(blockNum) {
+		add("LENDING_REGISTRATION_SMC", c.LendingRegistrationSMC)
+	}
+	if c.IsTIPXDCXReceiver(blockNum) {
+		add("XDCX_ADDRESS", common.XDCXAddrBinary)
+		add("TRADING_STATE_ADDRESS", common.TradingStateAddrBinary)
+		add("XDCX_LENDING_ADDRESS", common.XDCXLendingAddressBinary)
+		add("XDCX_LENDING_FINALIZED_TRADE_ADDRESS", common.XDCXLendingFinalizedTradeAddressBinary)
+	}
+	if c.IsTIPTRC21Fee(blockNum) {
+		add("TRC21_ISSUER_SMC", c.TRC21IssuerSMC)
+	}
+	if c.IsPrague(blockNum) {
+		active["HISTORY_STORAGE_ADDRESS"] = HistoryStorageAddress
+	}
+	return active
 }

--- a/params/config_forks.go
+++ b/params/config_forks.go
@@ -140,6 +140,11 @@ func (c *ChainConfig) IsShanghai(num *big.Int) bool {
 	return isForked(c.ShanghaiBlock, num)
 }
 
+// IsXDPoSV2 returns whether num is either equal to the XDPoS V2 switch block or greater.
+func (c *ChainConfig) IsXDPoSV2(num *big.Int) bool {
+	return c.XDPoS != nil && c.XDPoS.V2 != nil && isForked(c.XDPoS.V2.SwitchBlock, num)
+}
+
 // IsGas50x returns whether num is either equal to the Gas50x fork block or greater.
 func (c *ChainConfig) IsGas50x(num *big.Int) bool {
 	return isForked(c.Gas50xBlock, num)

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"errors"
 	"math/big"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -804,6 +806,240 @@ func TestChainConfigUnmarshalJSONResetsRuntimeOnlyMetadata(t *testing.T) {
 	}
 }
 
+func TestGatherForksIncludesXDPoSV2SwitchBlock(t *testing.T) {
+	config := &ChainConfig{
+		HomesteadBlock: big.NewInt(0),
+		BerlinBlock:    big.NewInt(1000),
+		EIP1559Block:   big.NewInt(1000),
+		XDPoS: &XDPoSConfig{V2: &V2{
+			SwitchBlock: big.NewInt(1500),
+		}},
+	}
+	// BerlinBlock and EIP1559Block are distinct fork fields that intentionally
+	// share the same height here; GatherForks must collapse that cross-field
+	// duplicate into a single block entry before appending the nested XDPoS V2 switch.
+	assert.Equal(t, []uint64{1000, 1500}, config.GatherForks())
+}
+
+func TestActiveForksReturnsAlphabeticalNames(t *testing.T) {
+	config := &ChainConfig{
+		HomesteadBlock:           big.NewInt(1),
+		ByzantiumBlock:           big.NewInt(1),
+		BerlinBlock:              big.NewInt(1),
+		EIP150Block:              big.NewInt(1),
+		EIP1559Block:             big.NewInt(1),
+		TIP2019Block:             big.NewInt(1),
+		TIPTRC21FeeBlock:         big.NewInt(1),
+		TIPXDCXBlock:             big.NewInt(1),
+		TIPXDCXMinerDisableBlock: big.NewInt(1),
+		DynamicGasLimitBlock:     big.NewInt(1),
+		XDPoS: &XDPoSConfig{V2: &V2{
+			SwitchBlock: big.NewInt(1),
+		}},
+	}
+
+	assert.Equal(t, []string{
+		"Berlin",
+		"Byzantium",
+		"DynamicGasLimit",
+		"EIP1559",
+		"Homestead",
+		"TIP2019",
+		"TIPTRC21Fee",
+		"TIPXDCX",
+		"TIPXDCXReceiver",
+		"TangerineWhistle",
+		"XDCxDisable",
+		"XDPoSV2",
+	}, config.ActiveForks(big.NewInt(1)))
+}
+
+func BenchmarkGatherForks(b *testing.B) {
+	config := &ChainConfig{
+		HomesteadBlock:              big.NewInt(0),
+		DAOForkBlock:                big.NewInt(1),
+		EIP150Block:                 big.NewInt(2),
+		EIP155Block:                 big.NewInt(3),
+		EIP158Block:                 big.NewInt(4),
+		ByzantiumBlock:              big.NewInt(5),
+		ConstantinopleBlock:         big.NewInt(6),
+		PetersburgBlock:             big.NewInt(7),
+		IstanbulBlock:               big.NewInt(8),
+		TIP2019Block:                big.NewInt(9),
+		TIPSigningBlock:             big.NewInt(10),
+		TIPRandomizeBlock:           big.NewInt(11),
+		TIPIncreaseMasternodesBlock: big.NewInt(12),
+		DenylistBlock:               big.NewInt(13),
+		TIPNoHalvingMNRewardBlock:   big.NewInt(14),
+		TIPXDCXBlock:                big.NewInt(15),
+		TIPXDCXLendingBlock:         big.NewInt(16),
+		TIPXDCXCancellationFeeBlock: big.NewInt(17),
+		TIPTRC21FeeBlock:            big.NewInt(18),
+		Gas50xBlock:                 big.NewInt(19),
+		BerlinBlock:                 big.NewInt(20),
+		LondonBlock:                 big.NewInt(21),
+		MergeBlock:                  big.NewInt(22),
+		ShanghaiBlock:               big.NewInt(23),
+		TIPXDCXMinerDisableBlock:    big.NewInt(24),
+		TIPXDCXReceiverDisableBlock: big.NewInt(25),
+		EIP1559Block:                big.NewInt(26),
+		CancunBlock:                 big.NewInt(27),
+		PragueBlock:                 big.NewInt(28),
+		OsakaBlock:                  big.NewInt(29),
+		DynamicGasLimitBlock:        big.NewInt(30),
+		TIPUpgradeRewardBlock:       big.NewInt(31),
+		TIPUpgradePenaltyBlock:      big.NewInt(32),
+		TIPEpochHalvingBlock:        big.NewInt(33),
+		XDPoS: &XDPoSConfig{V2: &V2{
+			SwitchBlock: big.NewInt(34),
+		}},
+	}
+
+	b.Run("current", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = config.GatherForks()
+		}
+	})
+	b.Run("legacy_reflection", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = gatherForksLegacyReflection(config)
+		}
+	})
+}
+
+func BenchmarkActiveForks(b *testing.B) {
+	config := &ChainConfig{
+		HomesteadBlock:              big.NewInt(0),
+		DAOForkBlock:                big.NewInt(1),
+		EIP150Block:                 big.NewInt(2),
+		EIP155Block:                 big.NewInt(3),
+		EIP158Block:                 big.NewInt(4),
+		ByzantiumBlock:              big.NewInt(5),
+		ConstantinopleBlock:         big.NewInt(6),
+		PetersburgBlock:             big.NewInt(7),
+		IstanbulBlock:               big.NewInt(8),
+		TIP2019Block:                big.NewInt(9),
+		TIPSigningBlock:             big.NewInt(10),
+		TIPRandomizeBlock:           big.NewInt(11),
+		TIPIncreaseMasternodesBlock: big.NewInt(12),
+		DenylistBlock:               big.NewInt(13),
+		TIPNoHalvingMNRewardBlock:   big.NewInt(14),
+		TIPXDCXBlock:                big.NewInt(15),
+		TIPXDCXLendingBlock:         big.NewInt(16),
+		TIPXDCXCancellationFeeBlock: big.NewInt(17),
+		TIPTRC21FeeBlock:            big.NewInt(18),
+		Gas50xBlock:                 big.NewInt(19),
+		BerlinBlock:                 big.NewInt(20),
+		LondonBlock:                 big.NewInt(21),
+		MergeBlock:                  big.NewInt(22),
+		ShanghaiBlock:               big.NewInt(23),
+		TIPXDCXMinerDisableBlock:    big.NewInt(24),
+		TIPXDCXReceiverDisableBlock: big.NewInt(40),
+		EIP1559Block:                big.NewInt(26),
+		CancunBlock:                 big.NewInt(27),
+		PragueBlock:                 big.NewInt(28),
+		OsakaBlock:                  big.NewInt(29),
+		DynamicGasLimitBlock:        big.NewInt(30),
+		TIPUpgradeRewardBlock:       big.NewInt(31),
+		TIPUpgradePenaltyBlock:      big.NewInt(32),
+		TIPEpochHalvingBlock:        big.NewInt(33),
+		XDPoS: &XDPoSConfig{V2: &V2{
+			SwitchBlock: big.NewInt(34),
+		}},
+	}
+	block := big.NewInt(35)
+
+	b.Run("current", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = config.ActiveForks(block)
+		}
+	})
+	b.Run("legacy_map_sort", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = activeForksLegacyMapSort(config, block)
+		}
+	})
+}
+
+func gatherForksLegacyReflection(c *ChainConfig) []uint64 {
+	kind := reflect.TypeFor[ChainConfig]()
+	conf := reflect.ValueOf(c).Elem()
+	forksByBlock := make([]uint64, 0)
+	for i := 0; i < kind.NumField(); i++ {
+		field := kind.Field(i)
+		if !strings.HasSuffix(field.Name, "Block") {
+			continue
+		}
+		if field.Type == reflect.TypeFor[*big.Int]() {
+			if rule := conf.Field(i).Interface().(*big.Int); rule != nil {
+				forksByBlock = append(forksByBlock, rule.Uint64())
+			}
+		}
+	}
+	if c.XDPoS != nil && c.XDPoS.V2 != nil && c.XDPoS.V2.SwitchBlock != nil {
+		forksByBlock = append(forksByBlock, c.XDPoS.V2.SwitchBlock.Uint64())
+	}
+	slices.Sort(forksByBlock)
+	forksByBlock = slices.Compact(forksByBlock)
+	if len(forksByBlock) > 0 && forksByBlock[0] == 0 {
+		forksByBlock = forksByBlock[1:]
+	}
+	return forksByBlock
+}
+
+func activeForksLegacyMapSort(c *ChainConfig, block *big.Int) []string {
+	features := map[string]bool{
+		"Homestead":              c.IsHomestead(block),
+		"DAO":                    c.IsDAOFork(block),
+		"TIP2019":                c.IsTIP2019(block),
+		"TangerineWhistle":       c.IsEIP150(block),
+		"SpuriousDragon":         c.IsEIP155(block),
+		"EIP158":                 c.IsEIP158(block),
+		"Byzantium":              c.IsByzantium(block),
+		"Constantinople":         c.IsConstantinople(block),
+		"Petersburg":             c.IsPetersburg(block),
+		"Istanbul":               c.IsIstanbul(block),
+		"TIPSigning":             c.IsTIPSigning(block),
+		"TIPRandomize":           c.IsTIPRandomize(block),
+		"TIPIncreaseMasternodes": c.IsTIPIncreaseMasternodes(block),
+		"Denylist":               c.IsDenylist(block),
+		"TIPNoHalvingMNReward":   c.IsTIPNoHalvingMNReward(block),
+		"TIPXDCX":                c.IsTIPXDCX(block),
+		"TIPXDCXLending":         c.IsTIPXDCXLending(block),
+		"TIPXDCXCancellationFee": c.IsTIPXDCXCancellationFee(block),
+		"TIPTRC21Fee":            c.IsTIPTRC21Fee(block),
+		"Berlin":                 c.IsBerlin(block),
+		"London":                 c.IsLondon(block),
+		"Merge":                  c.IsMerge(block),
+		"Shanghai":               c.IsShanghai(block),
+		"Gas50x":                 c.IsGas50x(block),
+		"XDPoSV2":                c.IsXDPoSV2(block),
+		"TIPXDCXMiner":           c.IsTIPXDCXMiner(block),
+		"TIPXDCXReceiver":        c.IsTIPXDCXReceiver(block),
+		"XDCxDisable":            c.IsXDCxDisable(block),
+		"EIP1559":                c.IsEIP1559(block),
+		"Cancun":                 c.IsCancun(block),
+		"DynamicGasLimit":        c.IsDynamicGasLimit(block),
+		"TIPUpgradeReward":       c.IsTIPUpgradeReward(block),
+		"TIPUpgradePenalty":      c.IsTIPUpgradePenalty(block),
+		"TIPEpochHalving":        c.IsTIPEpochHalving(block),
+		"Prague":                 c.IsPrague(block),
+		"Osaka":                  c.IsOsaka(block),
+	}
+	activeForks := make([]string, 0)
+	for fork, active := range features {
+		if active {
+			activeForks = append(activeForks, fork)
+		}
+	}
+	slices.Sort(activeForks)
+	return activeForks
+}
+
 func TestChainConfigStringIncludesAllFields(t *testing.T) {
 	config := &ChainConfig{
 		ChainID:                     big.NewInt(1),
@@ -916,5 +1152,167 @@ func TestChainConfigStringIncludesAllFields(t *testing.T) {
 		"XDPoS:",
 	} {
 		assert.Contains(t, got, label)
+	}
+}
+
+func TestActiveSystemContractsTracksXDCActivationBlocks(t *testing.T) {
+	config := &ChainConfig{
+		TIPSigningBlock:             big.NewInt(10),
+		TIPRandomizeBlock:           big.NewInt(20),
+		TIPXDCXBlock:                big.NewInt(30),
+		TIPXDCXLendingBlock:         big.NewInt(40),
+		TIPTRC21FeeBlock:            big.NewInt(50),
+		TIPXDCXMinerDisableBlock:    big.NewInt(55),
+		TIPXDCXReceiverDisableBlock: big.NewInt(56),
+		PragueBlock:                 big.NewInt(60),
+		TRC21IssuerSMC:              common.HexToAddress("0x0000000000000000000000000000000000000101"),
+		XDCXListingSMC:              common.HexToAddress("0x0000000000000000000000000000000000000102"),
+		RelayerRegistrationSMC:      common.HexToAddress("0x0000000000000000000000000000000000000103"),
+		LendingRegistrationSMC:      common.HexToAddress("0x0000000000000000000000000000000000000104"),
+		XDPoS:                       &XDPoSConfig{},
+	}
+
+	tests := []struct {
+		name  string
+		block uint64
+		want  map[string]common.Address
+	}{
+		{
+			name:  "genesis only validator contract",
+			block: 0,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC": common.MasternodeVotingSMCBinary,
+				"BLOCK_SIGNERS":         common.BlockSignersBinary,
+			},
+		},
+		{
+			name:  "pre signing exposes legacy block signer contract",
+			block: 9,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC": common.MasternodeVotingSMCBinary,
+				"BLOCK_SIGNERS":         common.BlockSignersBinary,
+			},
+		},
+		{
+			name:  "signing fork removes legacy block signer contract",
+			block: 10,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC": common.MasternodeVotingSMCBinary,
+			},
+		},
+		{
+			name:  "randomize fork adds randomize contract",
+			block: 20,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC": common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":         common.RandomizeSMCBinary,
+			},
+		},
+		{
+			name:  "xdcx fork adds receiver-routed exchange contracts",
+			block: 30,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC":                common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":                        common.RandomizeSMCBinary,
+				"XDCX_LISTING_SMC":                     config.XDCXListingSMC,
+				"RELAYER_REGISTRATION_SMC":             config.RelayerRegistrationSMC,
+				"XDCX_ADDRESS":                         common.XDCXAddrBinary,
+				"TRADING_STATE_ADDRESS":                common.TradingStateAddrBinary,
+				"XDCX_LENDING_ADDRESS":                 common.XDCXLendingAddressBinary,
+				"XDCX_LENDING_FINALIZED_TRADE_ADDRESS": common.XDCXLendingFinalizedTradeAddressBinary,
+			},
+		},
+		{
+			name:  "receiver routing exposes lending endpoints before lending fork",
+			block: 39,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC":                common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":                        common.RandomizeSMCBinary,
+				"XDCX_LISTING_SMC":                     config.XDCXListingSMC,
+				"RELAYER_REGISTRATION_SMC":             config.RelayerRegistrationSMC,
+				"XDCX_ADDRESS":                         common.XDCXAddrBinary,
+				"TRADING_STATE_ADDRESS":                common.TradingStateAddrBinary,
+				"XDCX_LENDING_ADDRESS":                 common.XDCXLendingAddressBinary,
+				"XDCX_LENDING_FINALIZED_TRADE_ADDRESS": common.XDCXLendingFinalizedTradeAddressBinary,
+			},
+		},
+		{
+			name:  "lending fork adds lending contracts",
+			block: 40,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC":                common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":                        common.RandomizeSMCBinary,
+				"XDCX_LISTING_SMC":                     config.XDCXListingSMC,
+				"RELAYER_REGISTRATION_SMC":             config.RelayerRegistrationSMC,
+				"XDCX_ADDRESS":                         common.XDCXAddrBinary,
+				"TRADING_STATE_ADDRESS":                common.TradingStateAddrBinary,
+				"LENDING_REGISTRATION_SMC":             config.LendingRegistrationSMC,
+				"XDCX_LENDING_ADDRESS":                 common.XDCXLendingAddressBinary,
+				"XDCX_LENDING_FINALIZED_TRADE_ADDRESS": common.XDCXLendingFinalizedTradeAddressBinary,
+			},
+		},
+		{
+			name:  "trc21 fork adds issuer contract",
+			block: 50,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC":                common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":                        common.RandomizeSMCBinary,
+				"TRC21_ISSUER_SMC":                     config.TRC21IssuerSMC,
+				"XDCX_LISTING_SMC":                     config.XDCXListingSMC,
+				"RELAYER_REGISTRATION_SMC":             config.RelayerRegistrationSMC,
+				"XDCX_ADDRESS":                         common.XDCXAddrBinary,
+				"TRADING_STATE_ADDRESS":                common.TradingStateAddrBinary,
+				"LENDING_REGISTRATION_SMC":             config.LendingRegistrationSMC,
+				"XDCX_LENDING_ADDRESS":                 common.XDCXLendingAddressBinary,
+				"XDCX_LENDING_FINALIZED_TRADE_ADDRESS": common.XDCXLendingFinalizedTradeAddressBinary,
+			},
+		},
+		{
+			name:  "prague adds history storage",
+			block: 60,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC":    common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":            common.RandomizeSMCBinary,
+				"TRC21_ISSUER_SMC":         config.TRC21IssuerSMC,
+				"XDCX_LISTING_SMC":         config.XDCXListingSMC,
+				"RELAYER_REGISTRATION_SMC": config.RelayerRegistrationSMC,
+				"LENDING_REGISTRATION_SMC": config.LendingRegistrationSMC,
+				"HISTORY_STORAGE_ADDRESS":  HistoryStorageAddress,
+			},
+		},
+		{
+			name:  "miner disable keeps receiver endpoints until receiver disable",
+			block: 55,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC":                common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":                        common.RandomizeSMCBinary,
+				"TRC21_ISSUER_SMC":                     config.TRC21IssuerSMC,
+				"XDCX_LISTING_SMC":                     config.XDCXListingSMC,
+				"RELAYER_REGISTRATION_SMC":             config.RelayerRegistrationSMC,
+				"XDCX_ADDRESS":                         common.XDCXAddrBinary,
+				"TRADING_STATE_ADDRESS":                common.TradingStateAddrBinary,
+				"LENDING_REGISTRATION_SMC":             config.LendingRegistrationSMC,
+				"XDCX_LENDING_ADDRESS":                 common.XDCXLendingAddressBinary,
+				"XDCX_LENDING_FINALIZED_TRADE_ADDRESS": common.XDCXLendingFinalizedTradeAddressBinary,
+			},
+		},
+		{
+			name:  "receiver disable removes xdcx receiver endpoints",
+			block: 56,
+			want: map[string]common.Address{
+				"MASTERNODE_VOTING_SMC":    common.MasternodeVotingSMCBinary,
+				"RANDOMIZE_SMC":            common.RandomizeSMCBinary,
+				"TRC21_ISSUER_SMC":         config.TRC21IssuerSMC,
+				"XDCX_LISTING_SMC":         config.XDCXListingSMC,
+				"RELAYER_REGISTRATION_SMC": config.RelayerRegistrationSMC,
+				"LENDING_REGISTRATION_SMC": config.LendingRegistrationSMC,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, config.ActiveSystemContracts(test.block))
+		})
 	}
 }

--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -1,0 +1,113 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package forks
+
+import "fmt"
+
+// Fork is a numerical identifier of specific network upgrades (forks).
+type Fork int
+
+const (
+	Frontier Fork = iota
+	FrontierThawing
+	Homestead
+	DAO
+	TIP2019
+	TangerineWhistle // a.k.a. the EIP150 fork
+	SpuriousDragon   // a.k.a. the EIP155 fork
+	EIP158
+	Byzantium
+	Constantinople
+	Petersburg
+	Istanbul
+	TIPSigning
+	TIPRandomize
+	TIPIncreaseMasternodes
+	Denylist
+	TIPNoHalvingMNReward
+	TIPXDCX
+	TIPXDCXLending
+	TIPXDCXCancellationFee
+	TIPTRC21Fee
+	Berlin
+	London
+	Merge
+	Shanghai
+	Gas50x
+	XDPoSV2
+	TIPXDCXMiner
+	TIPXDCXReceiver
+	XDCxDisable
+	EIP1559
+	Cancun
+	DynamicGasLimit
+	TIPUpgradeReward
+	TIPUpgradePenalty
+	TIPEpochHalving
+	Prague
+	Osaka
+)
+
+// String implements fmt.Stringer.
+func (f Fork) String() string {
+	s, ok := forkToString[f]
+	if !ok {
+		return fmt.Sprintf("Unknown fork (%d)", f)
+	}
+	return s
+}
+
+var forkToString = map[Fork]string{
+	Frontier:               "Frontier",
+	FrontierThawing:        "FrontierThawing",
+	Homestead:              "Homestead",
+	DAO:                    "DAO",
+	TIP2019:                "TIP2019",
+	TangerineWhistle:       "TangerineWhistle",
+	SpuriousDragon:         "SpuriousDragon",
+	EIP158:                 "EIP158",
+	Byzantium:              "Byzantium",
+	Constantinople:         "Constantinople",
+	Petersburg:             "Petersburg",
+	Istanbul:               "Istanbul",
+	TIPSigning:             "TIPSigning",
+	TIPRandomize:           "TIPRandomize",
+	TIPIncreaseMasternodes: "TIPIncreaseMasternodes",
+	Denylist:               "Denylist",
+	TIPNoHalvingMNReward:   "TIPNoHalvingMNReward",
+	TIPXDCX:                "TIPXDCX",
+	TIPXDCXLending:         "TIPXDCXLending",
+	TIPXDCXCancellationFee: "TIPXDCXCancellationFee",
+	TIPTRC21Fee:            "TIPTRC21Fee",
+	Berlin:                 "Berlin",
+	London:                 "London",
+	Merge:                  "Merge",
+	Shanghai:               "Shanghai",
+	Gas50x:                 "Gas50x",
+	XDPoSV2:                "XDPoSV2",
+	TIPXDCXMiner:           "TIPXDCXMiner",
+	TIPXDCXReceiver:        "TIPXDCXReceiver",
+	XDCxDisable:            "XDCxDisable",
+	EIP1559:                "EIP1559",
+	Cancun:                 "Cancun",
+	DynamicGasLimit:        "DynamicGasLimit",
+	TIPUpgradeReward:       "TIPUpgradeReward",
+	TIPUpgradePenalty:      "TIPUpgradePenalty",
+	TIPEpochHalving:        "TIPEpochHalving",
+	Prague:                 "Prague",
+	Osaka:                  "Osaka",
+}


### PR DESCRIPTION
# Proposed changes

Build the XDPoS config response from shared helpers that expose activation blocks, fork IDs, active fork labels, named precompiles, and active system contracts.

Expose the RPC through the XDPoS namespace and web3 extension, and document the response shape for current, next, and last block-based fork boundaries.

Add fork metadata, fork ID, and config snapshot tests to cover the new RPC payload and supporting chain-config helpers.

Ref: #32230

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [X] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
