### PR TITLE
fix(consensus): signature dedup construction check

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/testing_utils.go
+++ b/consensus/XDPoS/engines/engine_v2/testing_utils.go
@@ -3,6 +3,7 @@ package engine_v2
 import (
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 )
 
@@ -90,4 +91,18 @@ func (x *XDPoS_v2) GetForensicsFaker() *Forensics {
 // WARN: This function is designed for testing purpose only!
 func (x *XDPoS_v2) GetTCEpochInfoFaker(chain consensus.ChainReader, timeoutRound types.Round) (*types.EpochSwitchInfo, error) {
 	return x.getTCEpochInfo(chain, timeoutRound)
+}
+
+// WARN: This function is designed for testing purpose only!
+func (x *XDPoS_v2) OnVotePoolThresholdReachedFaker(chain consensus.ChainReader, pooledVotes map[common.Hash]utils.PoolObj, currentVoteMsg utils.PoolObj, proposedBlockHeader *types.Header) error {
+	x.lock.Lock()
+	defer x.lock.Unlock()
+	return x.onVotePoolThresholdReached(chain, pooledVotes, currentVoteMsg, proposedBlockHeader)
+}
+
+// WARN: This function is designed for testing purpose only!
+func (x *XDPoS_v2) OnTimeoutPoolThresholdReachedFaker(chain consensus.ChainReader, pooledTimeouts map[common.Hash]utils.PoolObj, currentTimeoutMsg utils.PoolObj, gapNumber uint64) error {
+	x.lock.Lock()
+	defer x.lock.Unlock()
+	return x.onTimeoutPoolThresholdReached(chain, pooledTimeouts, currentTimeoutMsg, gapNumber)
 }

--- a/consensus/XDPoS/engines/engine_v2/timeout.go
+++ b/consensus/XDPoS/engines/engine_v2/timeout.go
@@ -88,18 +88,50 @@ In the engine v2, we will need to:
  3. generateSyncInfo()
 */
 func (x *XDPoS_v2) onTimeoutPoolThresholdReached(blockChainReader consensus.ChainReader, pooledTimeouts map[common.Hash]utils.PoolObj, currentTimeoutMsg utils.PoolObj, gapNumber uint64) error {
-	signatures := []types.Signature{}
+	timeoutRound := currentTimeoutMsg.(*types.Timeout).Round
+
+	emptySigner := common.Address{}
+	var signatures []types.Signature
 	for _, v := range pooledTimeouts {
-		signatures = append(signatures, v.(*types.Timeout).Signature)
+		t := v.(*types.Timeout)
+		if t.GetSigner() == emptySigner {
+			continue
+		}
+		signatures = append(signatures, t.Signature)
 	}
-	// Genrate TC
+
+	epochInfo, err := x.getTCEpochInfo(blockChainReader, timeoutRound)
+	if err != nil {
+		log.Error("[onTimeoutPoolThresholdReached] Fail to get epochInfo", "tcRound", timeoutRound, "tcGapNumber", gapNumber, "error", err)
+		return err
+	}
+
+	// verify and deduplicate; drop invalid/duplicate timeouts rather than bail,
+	// so a single byzantine sender cannot stall TC generation for a round
+	signedTimeoutObj := types.TimeoutSigHash(&types.TimeoutForSign{
+		Round:     timeoutRound,
+		GapNumber: gapNumber,
+	})
+	validSignatures, _, duplicates, err := x.verifyAllSignatures(signedTimeoutObj, signatures, epochInfo.Masternodes)
+	if err != nil {
+		log.Warn("[onTimeoutPoolThresholdReached] some timeout signatures failed verification, continuing with valid subset", "error", err)
+	}
+	if len(duplicates) > 0 {
+		log.Warn("[onTimeoutPoolThresholdReached] duplicate signers in timeout pool, dropping duplicates", "duplicates", duplicates)
+	}
+
+	certThreshold := x.config.V2.Config(uint64(timeoutRound)).CertThreshold
+	if float64(len(validSignatures)) < float64(epochInfo.MasternodesLen)*certThreshold {
+		log.Warn("[onTimeoutPoolThresholdReached] Not enough valid signatures to generate TC", "numValid", len(validSignatures), "numTimeouts", len(pooledTimeouts), "certThreshold", float64(epochInfo.MasternodesLen)*certThreshold)
+		return nil
+	}
+
 	timeoutCert := &types.TimeoutCert{
-		Round:      currentTimeoutMsg.(*types.Timeout).Round,
-		Signatures: signatures,
+		Round:      timeoutRound,
+		Signatures: validSignatures,
 		GapNumber:  gapNumber,
 	}
-	// Process TC
-	err := x.processTC(blockChainReader, timeoutCert)
+	err = x.processTC(blockChainReader, timeoutCert)
 	if err != nil {
 		log.Error("[onTimeoutPoolThresholdReached] Fail to process TC", "TcRound", timeoutCert.Round, "NumberOfTcSig", len(timeoutCert.Signatures), "GapNumber", gapNumber, "Error", err)
 		return err

--- a/consensus/XDPoS/engines/engine_v2/utils.go
+++ b/consensus/XDPoS/engines/engine_v2/utils.go
@@ -1,11 +1,11 @@
 package engine_v2
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math/big"
 	"runtime"
+	"sync"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts"
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -16,7 +16,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/crypto/keccak"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
-	"golang.org/x/sync/errgroup"
 )
 
 func sigHash(header *types.Header) (hash common.Hash) {
@@ -95,51 +94,67 @@ func (x *XDPoS_v2) signSignature(signingHash common.Hash) (types.Signature, erro
 	return signedHash, nil
 }
 
-func (x *XDPoS_v2) countValidSignatures(messageHash common.Hash, signatures []types.Signature, candidates []common.Address) (int, error) {
-	signatureList := make([]types.Signature, len(signatures))
+func (x *XDPoS_v2) verifyAllSignatures(messageHash common.Hash, signatures []types.Signature, candidates []common.Address) (validSignatures []types.Signature, signers []common.Address, duplicates []common.Address, err error) {
+	errs := make([]error, len(signatures))
 	pubkeys := make([]common.Address, len(signatures))
+	ok := make([]bool, len(signatures))
 
-	eg, ctx := errgroup.WithContext(context.Background())
-	eg.SetLimit(runtime.NumCPU())
+	sem := make(chan struct{}, runtime.NumCPU())
+	var wg sync.WaitGroup
 	for i, signature := range signatures {
-		eg.Go(func() error {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			verified, signerAddress, verr := x.verifyMsgSignature(messageHash, signature, candidates)
+			switch {
+			case verr != nil:
+				log.Warn("[verifyAllSignatures] error verifying signature", "index", i, "message", messageHash.Hex(), "error", verr)
+				errs[i] = fmt.Errorf("verify sig %d: %w", i, verr)
+			case !verified:
+				log.Warn("[verifyAllSignatures] signer not in masternode list", "index", i, "signer", signerAddress, "message", messageHash.Hex())
+				errs[i] = fmt.Errorf("verify sig %d: signer %v not in masternodes", i, signerAddress)
 			default:
-				verified, signerAddress, err := x.verifyMsgSignature(messageHash, signature, candidates)
-				if err != nil {
-					log.Error("[verifySignatures] Error while verifying QC message signatures", "error", err)
-					return err
-				}
-				if !verified {
-					return fmt.Errorf("signature verification failed, signer is not part of masternode list. Signature: %v, SignedMessage: %v, SignerAddress: %v, Masternodes: %v", signature, messageHash.Hex(), signerAddress, candidates)
-				}
-				signatureList[i] = signature
 				pubkeys[i] = signerAddress
-
-				return nil
+				ok[i] = true
 			}
-		})
+		}()
 	}
-	err := eg.Wait()
+	wg.Wait()
+
+	seen := make(map[common.Address]struct{}, len(pubkeys))
+	dupSeen := make(map[common.Address]struct{})
+	validSignatures = make([]types.Signature, 0, len(pubkeys))
+	signers = make([]common.Address, 0, len(pubkeys))
+	for i, pubkey := range pubkeys {
+		if !ok[i] {
+			continue
+		}
+		if _, already := seen[pubkey]; already {
+			if _, reported := dupSeen[pubkey]; !reported {
+				log.Warn("[verifyAllSignatures] duplicate signer", "signer", pubkey, "message", messageHash.Hex())
+				duplicates = append(duplicates, pubkey)
+				dupSeen[pubkey] = struct{}{}
+			}
+			continue
+		}
+		seen[pubkey] = struct{}{}
+		signers = append(signers, pubkey)
+		validSignatures = append(validSignatures, signatures[i])
+	}
+	return validSignatures, signers, duplicates, errors.Join(errs...)
+}
+
+func (x *XDPoS_v2) countValidSignatures(messageHash common.Hash, signatures []types.Signature, candidates []common.Address) (int, error) {
+	_, signers, duplicates, err := x.verifyAllSignatures(messageHash, signatures, candidates)
 	if err != nil {
 		return 0, err
 	}
-
-	// check uniqueness
-	keys := make(map[common.Address]struct{}, len(signatureList))
-	for i := range signatureList {
-		pubkeyHex := pubkeys[i]
-		if _, ok := keys[pubkeyHex]; !ok {
-			keys[pubkeyHex] = struct{}{}
-		} else {
-			log.Warn("[verifySignatures] duplicate signing found", "pubkey", pubkeyHex, "signedMessage", messageHash.Hex(), "signature", signatureList[i])
-			return 0, fmt.Errorf("duplicate signing found, pubkey: %v, message: %v, signature: %v", pubkeyHex, messageHash.Hex(), common.Bytes2Hex(signatureList[i]))
-		}
+	if len(duplicates) > 0 {
+		return 0, fmt.Errorf("duplicate signers: %v, message: %v", duplicates, messageHash.Hex())
 	}
-
-	return len(keys), nil
+	return len(signers), nil
 }
 
 func (x *XDPoS_v2) verifyMsgSignature(signedHashToBeVerified common.Hash, signature types.Signature, masternodes []common.Address) (bool, common.Address, error) {

--- a/consensus/XDPoS/engines/engine_v2/utils_test.go
+++ b/consensus/XDPoS/engines/engine_v2/utils_test.go
@@ -1,0 +1,226 @@
+package engine_v2
+
+import (
+	"crypto/ecdsa"
+	"strings"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func addrOf(k *ecdsa.PrivateKey) common.Address {
+	return crypto.PubkeyToAddress(k.PublicKey)
+}
+
+func signMsg(t *testing.T, k *ecdsa.PrivateKey, h common.Hash) types.Signature {
+	t.Helper()
+	sig, err := crypto.Sign(h.Bytes(), k)
+	if err != nil {
+		t.Fatalf("crypto.Sign: %v", err)
+	}
+	return sig
+}
+
+func TestVerifyAllSignatures_AllValidUnique(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xdeadbeef")
+
+	k1, _ := crypto.GenerateKey()
+	k2, _ := crypto.GenerateKey()
+	k3, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1), addrOf(k2), addrOf(k3)}
+	sigs := []types.Signature{
+		signMsg(t, k1, msg),
+		signMsg(t, k2, msg),
+		signMsg(t, k3, msg),
+	}
+
+	valid, signers, dups, err := x.verifyAllSignatures(msg, sigs, candidates)
+	assert.NoError(t, err)
+	assert.Empty(t, dups)
+	assert.Len(t, valid, 3)
+	assert.Equal(t, candidates, signers, "signers preserve input order")
+	for i, sig := range sigs {
+		assert.Equal(t, sig, valid[i], "validSignatures parallel to signers")
+	}
+}
+
+func TestVerifyAllSignatures_EmptyInput(t *testing.T) {
+	x := &XDPoS_v2{}
+	candidates := []common.Address{common.HexToAddress("0x1")}
+
+	valid, signers, dups, err := x.verifyAllSignatures(common.HexToHash("0x1"), nil, candidates)
+	assert.NoError(t, err)
+	assert.Empty(t, valid)
+	assert.Empty(t, signers)
+	assert.Empty(t, dups)
+}
+
+func TestVerifyAllSignatures_NonMasternodeFiltered(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xfeed")
+	k1, _ := crypto.GenerateKey()
+	kStranger, _ := crypto.GenerateKey() // not in candidates
+	k3, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1), addrOf(k3)}
+	sigs := []types.Signature{
+		signMsg(t, k1, msg),
+		signMsg(t, kStranger, msg),
+		signMsg(t, k3, msg),
+	}
+
+	valid, signers, dups, err := x.verifyAllSignatures(msg, sigs, candidates)
+	assert.Error(t, err, "stranger signer should produce a joined error")
+	assert.Empty(t, dups)
+	assert.Len(t, valid, 2, "only valid signers kept")
+	assert.Equal(t, []common.Address{addrOf(k1), addrOf(k3)}, signers)
+}
+
+func TestVerifyAllSignatures_DuplicateSignerDeduped(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xcafe")
+	k1, _ := crypto.GenerateKey()
+	k2, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1), addrOf(k2)}
+	sig1 := signMsg(t, k1, msg)
+	sig2 := signMsg(t, k2, msg)
+
+	// k1 represented twice — even byte-identical, dedup must catch it
+	sigs := []types.Signature{sig1, sig1, sig2}
+
+	valid, signers, dups, err := x.verifyAllSignatures(msg, sigs, candidates)
+	assert.NoError(t, err, "duplicates are not verification errors")
+	assert.Equal(t, []common.Address{addrOf(k1)}, dups, "k1 reported as duplicate exactly once")
+	assert.Len(t, valid, 2, "first occurrence kept, second dropped")
+	assert.Equal(t, []common.Address{addrOf(k1), addrOf(k2)}, signers)
+}
+
+func TestVerifyAllSignatures_DuplicateReportedOncePerAddress(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xbeef")
+	k1, _ := crypto.GenerateKey()
+	k2, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1), addrOf(k2)}
+	sig1 := signMsg(t, k1, msg)
+	sig2 := signMsg(t, k2, msg)
+
+	// k1 appears 4 times, k2 appears 3 times
+	sigs := []types.Signature{sig1, sig1, sig1, sig1, sig2, sig2, sig2}
+
+	_, _, dups, err := x.verifyAllSignatures(msg, sigs, candidates)
+	assert.NoError(t, err)
+	assert.Len(t, dups, 2, "each duplicated signer listed once, regardless of count")
+	assert.ElementsMatch(t, []common.Address{addrOf(k1), addrOf(k2)}, dups)
+}
+
+func TestVerifyAllSignatures_EmptyCandidatesAllError(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xfade")
+	k1, _ := crypto.GenerateKey()
+	sigs := []types.Signature{signMsg(t, k1, msg)}
+
+	valid, signers, dups, err := x.verifyAllSignatures(msg, sigs, nil)
+	assert.Error(t, err, "empty masternodes makes every signature invalid")
+	assert.Empty(t, valid)
+	assert.Empty(t, signers)
+	assert.Empty(t, dups)
+}
+
+func TestVerifyAllSignatures_GarbageSignatureKeepsValid(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xbabe")
+	k1, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1)}
+	garbage := make(types.Signature, 65) // all zeros, ecrecover fails
+
+	valid, signers, _, err := x.verifyAllSignatures(msg, []types.Signature{signMsg(t, k1, msg), garbage}, candidates)
+	assert.Error(t, err, "garbage signature contributes an error")
+	assert.Len(t, valid, 1, "valid signature still recovered")
+	assert.Equal(t, addrOf(k1), signers[0])
+}
+
+func TestVerifyAllSignatures_OrderPreservedFirstOccurrence(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xface")
+	k1, _ := crypto.GenerateKey()
+	k2, _ := crypto.GenerateKey()
+	k3, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1), addrOf(k2), addrOf(k3)}
+
+	// Ordering: k2, k1, k2 (dup), k3 — first-occurrence order is k2, k1, k3
+	sigs := []types.Signature{
+		signMsg(t, k2, msg),
+		signMsg(t, k1, msg),
+		signMsg(t, k2, msg), // duplicate of position 0
+		signMsg(t, k3, msg),
+	}
+	_, signers, dups, err := x.verifyAllSignatures(msg, sigs, candidates)
+	assert.NoError(t, err)
+	assert.Equal(t, []common.Address{addrOf(k2)}, dups)
+	assert.Equal(t, []common.Address{addrOf(k2), addrOf(k1), addrOf(k3)}, signers)
+}
+
+func TestCountValidSignatures_AllValidReturnsCount(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xa")
+	k1, _ := crypto.GenerateKey()
+	k2, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1), addrOf(k2)}
+	sigs := []types.Signature{signMsg(t, k1, msg), signMsg(t, k2, msg)}
+
+	n, err := x.countValidSignatures(msg, sigs, candidates)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestCountValidSignatures_FailsOnNonMasternode(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xb")
+	k1, _ := crypto.GenerateKey()
+	kStranger, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1)}
+	sigs := []types.Signature{signMsg(t, k1, msg), signMsg(t, kStranger, msg)}
+
+	n, err := x.countValidSignatures(msg, sigs, candidates)
+	assert.Error(t, err)
+	assert.Equal(t, 0, n, "strict adapter returns 0 on any verification failure")
+}
+
+func TestCountValidSignatures_FailsOnDuplicate(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xc")
+	k1, _ := crypto.GenerateKey()
+	k2, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1), addrOf(k2)}
+	sig1 := signMsg(t, k1, msg)
+	sigs := []types.Signature{sig1, sig1, signMsg(t, k2, msg)}
+
+	n, err := x.countValidSignatures(msg, sigs, candidates)
+	assert.Error(t, err, "strict adapter rejects duplicates")
+	assert.Equal(t, 0, n)
+	assert.True(t, strings.Contains(err.Error(), "duplicate"), "error mentions duplicate: %v", err)
+}
+
+func TestCountValidSignatures_EmptyInputReturnsZero(t *testing.T) {
+	x := &XDPoS_v2{}
+	k1, _ := crypto.GenerateKey()
+	candidates := []common.Address{addrOf(k1)}
+
+	n, err := x.countValidSignatures(common.HexToHash("0xd"), nil, candidates)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestCountValidSignatures_EmptyCandidatesErrors(t *testing.T) {
+	x := &XDPoS_v2{}
+	msg := common.HexToHash("0xe")
+	k1, _ := crypto.GenerateKey()
+	sigs := []types.Signature{signMsg(t, k1, msg)}
+
+	n, err := x.countValidSignatures(msg, sigs, nil)
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}

--- a/consensus/XDPoS/engines/engine_v2/vote.go
+++ b/consensus/XDPoS/engines/engine_v2/vote.go
@@ -227,13 +227,27 @@ func (x *XDPoS_v2) onVotePoolThresholdReached(chain consensus.ChainReader, poole
 		return errors.New("fail on voteHandler due to failure in getting epoch switch info")
 	}
 
+	// verify and deduplicate; drop invalid/duplicate votes rather than bail,
+	// so a single byzantine sender cannot stall QC generation for a round
+	signedVoteObj := types.VoteSigHash(&types.VoteForSign{
+		ProposedBlockInfo: currentVoteMsg.(*types.Vote).ProposedBlockInfo,
+		GapNumber:         currentVoteMsg.(*types.Vote).GapNumber,
+	})
+	validSignatures, _, duplicates, err := x.verifyAllSignatures(signedVoteObj, validSignatures, epochInfo.Masternodes)
+	if err != nil {
+		log.Warn("[onVotePoolThresholdReached] some vote signatures failed verification, continuing with valid subset", "error", err)
+	}
+	if len(duplicates) > 0 {
+		log.Warn("[onVotePoolThresholdReached] duplicate signers in vote pool, dropping duplicates", "duplicates", duplicates)
+	}
+
 	// Skip and wait for the next vote to process again if valid votes is less than what we required
 	certThreshold := x.config.V2.Config(uint64(currentVoteMsg.(*types.Vote).ProposedBlockInfo.Round)).CertThreshold
 	if float64(len(validSignatures)) < float64(epochInfo.MasternodesLen)*certThreshold {
 		log.Warn("[onVotePoolThresholdReached] Not enough valid signatures to generate QC", "VotesSignaturesAfterFilter", validSignatures, "NumberOfValidVotes", len(validSignatures), "NumberOfVotes", len(pooledVotes))
 		return nil
 	}
-	// Genrate QC
+	// Generate QC
 	quorumCert := &types.QuorumCert{
 		ProposedBlockInfo: currentVoteMsg.(*types.Vote).ProposedBlockInfo,
 		Signatures:        validSignatures,

--- a/consensus/tests/engine_v2_tests/duplicate_signing_test.go
+++ b/consensus/tests/engine_v2_tests/duplicate_signing_test.go
@@ -1,0 +1,207 @@
+package engine_v2_tests
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/accounts"
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVoteQCGeneration_DeduplicatesByzantineSigner verifies that when the vote
+// pool contains two pool entries from the same signer (the byzantine
+// amplification scenario described in the refactor), QC generation succeeds
+// and the resulting QC contains exactly one signature per unique signer.
+//
+// In production the pool keys by vote-hash so byte-identical votes naturally
+// dedupe; this test simulates an attacker using non-deterministic signing by
+// inserting two pool entries that resolve to the same signer.
+func TestVoteQCGeneration_DeduplicatesByzantineSigner(t *testing.T) {
+	blockchain, _, currentBlock, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 901, params.TestXDPoSMockChainConfig, nil)
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	blockInfo := &types.BlockInfo{
+		Hash:   currentBlock.Hash(),
+		Round:  types.Round(1),
+		Number: big.NewInt(901),
+	}
+	voteForSign := &types.VoteForSign{ProposedBlockInfo: blockInfo, GapNumber: 450}
+	voteSigningHash := types.VoteSigHash(voteForSign)
+
+	engineV2.SetNewRoundFaker(blockchain, types.Round(1), false)
+
+	sigSigner, err := signFn(accounts.Account{Address: signer}, voteSigningHash.Bytes())
+	assert.Nil(t, err)
+	sigAcc1 := SignHashByPK(acc1Key, voteSigningHash.Bytes())
+	sigAcc2 := SignHashByPK(acc2Key, voteSigningHash.Bytes())
+	sigAcc3 := SignHashByPK(acc3Key, voteSigningHash.Bytes())
+
+	build := func(sig types.Signature, addr common.Address) *types.Vote {
+		v := &types.Vote{ProposedBlockInfo: blockInfo, Signature: sig, GapNumber: 450}
+		v.SetSigner(addr)
+		return v
+	}
+
+	pooledVotes := map[common.Hash]utils.PoolObj{
+		common.HexToHash("0x01"): build(sigSigner, signer),
+		common.HexToHash("0x02"): build(sigAcc1, acc1Addr),
+		common.HexToHash("0x03"): build(sigAcc2, acc2Addr),
+		common.HexToHash("0x04"): build(sigAcc3, acc3Addr),
+		// duplicate of acc1 — different map key but same signer/sig
+		common.HexToHash("0x05"): build(sigAcc1, acc1Addr),
+	}
+
+	currentVoteMsg := build(sigAcc3, acc3Addr)
+	proposedHeader := blockchain.GetHeaderByHash(currentBlock.Hash())
+
+	err = engineV2.OnVotePoolThresholdReachedFaker(blockchain, pooledVotes, currentVoteMsg, proposedHeader)
+	assert.Nil(t, err, "QC generation should succeed despite duplicate")
+
+	_, _, highestQC, _, _, _ := engineV2.GetPropertiesFaker()
+	assert.Equal(t, types.Round(1), highestQC.ProposedBlockInfo.Round, "QC should be set for round 1")
+	assert.Len(t, highestQC.Signatures, 4, "QC should contain exactly 4 signatures, duplicate dropped")
+
+	// Each surviving signature must come from a distinct masternode.
+	expectedSigs := []types.Signature{sigSigner, sigAcc1, sigAcc2, sigAcc3}
+	assert.ElementsMatch(t, expectedSigs, highestQC.Signatures)
+}
+
+// TestVoteQCGeneration_BelowThresholdAfterDedupSkipsQC verifies that when
+// duplicates inflate the pool past threshold but the unique-signer count
+// after dedup is below threshold, no QC is generated. This is the byzantine
+// "trip threshold with padding" scenario the new dedup defends against.
+func TestVoteQCGeneration_BelowThresholdAfterDedupSkipsQC(t *testing.T) {
+	blockchain, _, currentBlock, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 901, params.TestXDPoSMockChainConfig, nil)
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	blockInfo := &types.BlockInfo{Hash: currentBlock.Hash(), Round: types.Round(1), Number: big.NewInt(901)}
+	voteSigningHash := types.VoteSigHash(&types.VoteForSign{ProposedBlockInfo: blockInfo, GapNumber: 450})
+
+	engineV2.SetNewRoundFaker(blockchain, types.Round(1), false)
+
+	sigSigner, err := signFn(accounts.Account{Address: signer}, voteSigningHash.Bytes())
+	assert.Nil(t, err)
+	sigAcc1 := SignHashByPK(acc1Key, voteSigningHash.Bytes())
+
+	build := func(sig types.Signature, addr common.Address) *types.Vote {
+		v := &types.Vote{ProposedBlockInfo: blockInfo, Signature: sig, GapNumber: 450}
+		v.SetSigner(addr)
+		return v
+	}
+
+	// Pool has 4 entries (enough to trip threshold by raw count), but only 2
+	// unique signers — below the 4-of-4 threshold for this test config.
+	pooledVotes := map[common.Hash]utils.PoolObj{
+		common.HexToHash("0x01"): build(sigSigner, signer),
+		common.HexToHash("0x02"): build(sigAcc1, acc1Addr),
+		common.HexToHash("0x03"): build(sigAcc1, acc1Addr), // dup
+		common.HexToHash("0x04"): build(sigAcc1, acc1Addr), // dup
+	}
+
+	currentVoteMsg := build(sigAcc1, acc1Addr)
+	proposedHeader := blockchain.GetHeaderByHash(currentBlock.Hash())
+
+	err = engineV2.OnVotePoolThresholdReachedFaker(blockchain, pooledVotes, currentVoteMsg, proposedHeader)
+	assert.Nil(t, err, "no error returned even when threshold is missed")
+
+	_, _, highestQC, _, _, _ := engineV2.GetPropertiesFaker()
+	assert.Equal(t, types.Round(0), highestQC.ProposedBlockInfo.Round, "no QC should be generated; highestQC stays at default")
+}
+
+// TestTCGeneration_DeduplicatesByzantineSigner is the timeout-side mirror:
+// duplicates in the timeout pool from the same signer must be dropped, and
+// the resulting TC must contain only one signature per unique signer.
+func TestTCGeneration_DeduplicatesByzantineSigner(t *testing.T) {
+	blockchain, _, _, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 905, params.TestXDPoSMockChainConfig, nil)
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	engineV2.SetNewRoundFaker(blockchain, types.Round(5), false)
+
+	timeoutSigningHash := types.TimeoutSigHash(&types.TimeoutForSign{
+		Round:     types.Round(5),
+		GapNumber: 450,
+	})
+
+	sigSigner, err := signFn(accounts.Account{Address: signer}, timeoutSigningHash.Bytes())
+	assert.Nil(t, err)
+	sigAcc1 := SignHashByPK(acc1Key, timeoutSigningHash.Bytes())
+	sigAcc2 := SignHashByPK(acc2Key, timeoutSigningHash.Bytes())
+	sigAcc3 := SignHashByPK(acc3Key, timeoutSigningHash.Bytes())
+
+	build := func(sig types.Signature, addr common.Address) *types.Timeout {
+		t := &types.Timeout{Round: types.Round(5), Signature: sig, GapNumber: 450}
+		t.SetSigner(addr)
+		return t
+	}
+
+	pooledTimeouts := map[common.Hash]utils.PoolObj{
+		common.HexToHash("0x01"): build(sigSigner, signer),
+		common.HexToHash("0x02"): build(sigAcc1, acc1Addr),
+		common.HexToHash("0x03"): build(sigAcc2, acc2Addr),
+		common.HexToHash("0x04"): build(sigAcc3, acc3Addr),
+		// duplicate of acc1
+		common.HexToHash("0x05"): build(sigAcc1, acc1Addr),
+	}
+
+	currentTimeoutMsg := build(sigAcc3, acc3Addr)
+
+	err = engineV2.OnTimeoutPoolThresholdReachedFaker(blockchain, pooledTimeouts, currentTimeoutMsg, 450)
+	assert.Nil(t, err, "TC generation should succeed despite duplicate")
+
+	_, _, _, highestTC, _, _ := engineV2.GetPropertiesFaker()
+	assert.NotNil(t, highestTC)
+	assert.Equal(t, types.Round(5), highestTC.Round)
+	assert.Equal(t, uint64(450), highestTC.GapNumber)
+	assert.Len(t, highestTC.Signatures, 4, "TC should contain exactly 4 signatures, duplicate dropped")
+
+	expectedSigs := []types.Signature{sigSigner, sigAcc1, sigAcc2, sigAcc3}
+	assert.ElementsMatch(t, expectedSigs, highestTC.Signatures)
+}
+
+// TestTCGeneration_BelowThresholdAfterDedupSkipsTC: timeout-side analogue —
+// pool tripped only by duplicates, unique signer count below threshold,
+// so no TC should be produced.
+func TestTCGeneration_BelowThresholdAfterDedupSkipsTC(t *testing.T) {
+	blockchain, _, _, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 905, params.TestXDPoSMockChainConfig, nil)
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	engineV2.SetNewRoundFaker(blockchain, types.Round(5), false)
+
+	timeoutSigningHash := types.TimeoutSigHash(&types.TimeoutForSign{
+		Round:     types.Round(5),
+		GapNumber: 450,
+	})
+
+	sigSigner, err := signFn(accounts.Account{Address: signer}, timeoutSigningHash.Bytes())
+	assert.Nil(t, err)
+	sigAcc1 := SignHashByPK(acc1Key, timeoutSigningHash.Bytes())
+
+	build := func(sig types.Signature, addr common.Address) *types.Timeout {
+		t := &types.Timeout{Round: types.Round(5), Signature: sig, GapNumber: 450}
+		t.SetSigner(addr)
+		return t
+	}
+
+	pooledTimeouts := map[common.Hash]utils.PoolObj{
+		common.HexToHash("0x01"): build(sigSigner, signer),
+		common.HexToHash("0x02"): build(sigAcc1, acc1Addr),
+		common.HexToHash("0x03"): build(sigAcc1, acc1Addr),
+		common.HexToHash("0x04"): build(sigAcc1, acc1Addr),
+	}
+
+	currentTimeoutMsg := build(sigAcc1, acc1Addr)
+
+	err = engineV2.OnTimeoutPoolThresholdReachedFaker(blockchain, pooledTimeouts, currentTimeoutMsg, 450)
+	assert.Nil(t, err, "no error when threshold missed after dedup")
+
+	_, _, _, highestTC, _, _ := engineV2.GetPropertiesFaker()
+	// highestTC starts as a default zero value (Round 0); no TC should be set.
+	if highestTC != nil {
+		assert.Equal(t, types.Round(0), highestTC.Round, "no TC should be generated; default highestTC remains")
+	}
+}

--- a/consensus/tests/engine_v2_tests/timeout_test.go
+++ b/consensus/tests/engine_v2_tests/timeout_test.go
@@ -145,57 +145,59 @@ func TestTimeoutPeriodAndThreadholdConfigChange(t *testing.T) {
 // Timeout handler
 func TestTimeoutMessageHandlerSuccessfullyGenerateTCandSyncInfoAfterReachingThreshold(t *testing.T) {
 	skipLongInShortMode(t)
-	blockchain, _, _, _, _, _ := PrepareXDCTestBlockChainForV2Engine(t, 905, params.TestXDPoSMockChainConfig, nil)
+	blockchain, _, _, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 905, params.TestXDPoSMockChainConfig, nil)
 	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
 
-	// Set round to 1
 	engineV2.SetNewRoundFaker(blockchain, types.Round(5), false)
-	// Create two timeout message which will not reach timeout pool threshold
-	timeoutMsg := &types.Timeout{
-		Round:     types.Round(5),
-		Signature: []byte{1},
-		GapNumber: 450,
-	}
 
-	err := engineV2.TimeoutHandler(blockchain, timeoutMsg)
+	timeoutSigningHash := types.TimeoutSigHash(&types.TimeoutForSign{
+		Round:     types.Round(5),
+		GapNumber: 450,
+	})
+
+	sigSigner, err := signFn(accounts.Account{Address: signer}, timeoutSigningHash.Bytes())
+	assert.Nil(t, err)
+	sigAcc1 := SignHashByPK(acc1Key, timeoutSigningHash.Bytes())
+	sigAcc2 := SignHashByPK(acc2Key, timeoutSigningHash.Bytes())
+	sigAcc3 := SignHashByPK(acc3Key, timeoutSigningHash.Bytes())
+
+	// TimeoutHandler bypasses VerifyTimeoutMessage, so the signer field is set
+	// manually here to mirror what the BFT entry path would set.
+	timeoutMsg := &types.Timeout{Round: types.Round(5), Signature: sigSigner, GapNumber: 450}
+	timeoutMsg.SetSigner(signer)
+	err = engineV2.TimeoutHandler(blockchain, timeoutMsg)
 	assert.Nil(t, err)
 	currentRound, _, _, _, _, _ := engineV2.GetPropertiesFaker()
 	assert.Equal(t, types.Round(5), currentRound)
-	timeoutMsg = &types.Timeout{
-		Round:     types.Round(5),
-		Signature: []byte{2},
-		GapNumber: 450,
-	}
+
+	timeoutMsg = &types.Timeout{Round: types.Round(5), Signature: sigAcc1, GapNumber: 450}
+	timeoutMsg.SetSigner(acc1Addr)
 	err = engineV2.TimeoutHandler(blockchain, timeoutMsg)
 	assert.Nil(t, err)
-	timeoutMsg = &types.Timeout{
-		Round:     types.Round(5),
-		Signature: []byte{3},
-		GapNumber: 450,
-	}
+
+	timeoutMsg = &types.Timeout{Round: types.Round(5), Signature: sigAcc2, GapNumber: 450}
+	timeoutMsg.SetSigner(acc2Addr)
 	err = engineV2.TimeoutHandler(blockchain, timeoutMsg)
 	assert.Nil(t, err)
 	currentRound, _, _, _, _, _ = engineV2.GetPropertiesFaker()
 	assert.Equal(t, types.Round(5), currentRound)
 
 	// Send a timeout with different gap number, it shall not trigger timeout pool hook
-	timeoutMsg = &types.Timeout{
+	otherGapHash := types.TimeoutSigHash(&types.TimeoutForSign{
 		Round:     types.Round(5),
-		Signature: []byte{4},
 		GapNumber: 1350,
-	}
+	})
+	sigOtherGap := SignHashByPK(acc3Key, otherGapHash.Bytes())
+	timeoutMsg = &types.Timeout{Round: types.Round(5), Signature: sigOtherGap, GapNumber: 1350}
+	timeoutMsg.SetSigner(acc3Addr)
 	err = engineV2.TimeoutHandler(blockchain, timeoutMsg)
 	assert.Nil(t, err)
 	currentRound, _, _, _, _, _ = engineV2.GetPropertiesFaker()
 	assert.Equal(t, types.Round(5), currentRound)
 
 	// Create a timeout message that should trigger timeout pool hook
-	timeoutMsg = &types.Timeout{
-		Round:     types.Round(5),
-		Signature: []byte{5},
-		GapNumber: 450,
-	}
-
+	timeoutMsg = &types.Timeout{Round: types.Round(5), Signature: sigAcc3, GapNumber: 450}
+	timeoutMsg.SetSigner(acc3Addr)
 	err = engineV2.TimeoutHandler(blockchain, timeoutMsg)
 	assert.Nil(t, err)
 
@@ -226,9 +228,9 @@ func TestTimeoutMessageHandlerSuccessfullyGenerateTCandSyncInfoAfterReachingThre
 	assert.NotNil(t, tc)
 	assert.Equal(t, tc.Round, types.Round(5))
 	assert.Equal(t, uint64(450), tc.GapNumber)
-	// The signatures shall not include the byte{3} from a different gap number
-	sigatures := []types.Signature{[]byte{1}, []byte{2}, []byte{3}, []byte{5}}
-	assert.ElementsMatch(t, tc.Signatures, sigatures)
+	// The signatures shall not include the different-gap signature
+	expectedSigs := []types.Signature{sigSigner, sigAcc1, sigAcc2, sigAcc3}
+	assert.ElementsMatch(t, tc.Signatures, expectedSigs)
 	assert.Equal(t, types.Round(6), currentRound)
 }
 

--- a/consensus/tests/engine_v2_tests/verify_header_test.go
+++ b/consensus/tests/engine_v2_tests/verify_header_test.go
@@ -409,7 +409,7 @@ func TestShouldFailIfNotEnoughQCSignatures(t *testing.T) {
 	headerWithDuplicatedSignatures.Extra = extraInBytes
 	// Happy path
 	err = adaptor.VerifyHeader(blockchain, headerWithDuplicatedSignatures, true)
-	assert.ErrorContains(t, err, "duplicate signing found")
+	assert.ErrorContains(t, err, "duplicate signers:")
 
 }
 


### PR DESCRIPTION
# Proposed changes

XDPoS v2 had a liveness vulnerability in the QC/TC authoring path where a single byzantine masternode could amplify their own valid signature into multiple pool entries — ECDSA non-determinism (custom random nonce) lets the same signer produce arbitrarily many byte-distinct valid signatures for the same vote/timeout message. These would inflate the pool past threshold prematurely, and the strict authoring path (`if count != len(validSignatures) → skip QC`) would then bail out, costing the leader a round. Repeated across rotating attackers, this could degrade chain liveness without breaking safety.

This PR consolidates signature verification onto a single primitive (`verifyAllSignatures`) used by every QC/TC verification site in the engine, and switches the **authoring** paths (`onVotePoolThresholdReached`, `onTimeoutPoolThresholdReached`) from strict-bail to lenient-filter — duplicate or invalid signatures are dropped, and a clean QC/TC is built from the unique verified subset if threshold is still met.

### What changed

- **New primitive** `verifyAllSignatures(messageHash, signatures, candidates) → (validSignatures, signers, duplicates, err)` — parallel ecrecover with NumCPU semaphore, dedup by recovered signer, returns deduplicated parallel slices plus the list of duplicate addresses and a joined error covering every failure.
- **`countValidSignatures` rewritten as a strict adapter** on top of the primitive — drop-in replacement for the previous implementation. Same `(int, error)` shape; `verifyQC`, `verifyTC`, `VerifyVoteMessage` callers unchanged.
- **`onVotePoolThresholdReached`** now uses the primitive directly: drops invalid/duplicate votes, rebuilds the signatures slice from the unique verified subset, threshold-rechecks against the deduplicated count.
- **`onTimeoutPoolThresholdReached`** gets the same treatment plus an explicit epoch-info lookup (was previously dumping raw pool signatures into the TC with no verification).
- Removed unused `context` and `errgroup` imports.

### Why lenient at authoring, strict at verification

- Verification side (received QC/TC from peer): a malformed QC means the producer is byzantine or buggy → reject. No liveness cost to us.
- Authoring side (we are the leader building a QC/TC from our own pool): bailing on one bad vote hands the round to the attacker. Safer to drop the bad entry and build a valid QC from what's good.

The output QC/TC is identical from peers' perspective in both cases — they verify the same way regardless of how it was constructed. No protocol change.

### Tests

- **`utils_test.go`** (in-package): 14 unit tests for `verifyAllSignatures` and `countValidSignatures` covering all-valid, empty input, non-masternode filtering, duplicate dedup, garbage signatures, ordering, and the strict-adapter error cases.
- **`duplicate_signing_test.go`** (cross-package integration): 4 tests exercising the QC and TC authoring paths under byzantine duplicate-signer scenarios — verifies that QCs/TCs are built with deduplicated signatures when duplicates inflate the pool, and that no QC/TC is generated when unique-signer count after dedup is below threshold.
- Two new test Fakers (`OnVotePoolThresholdReachedFaker`, `OnTimeoutPoolThresholdReachedFaker`).
- **`TestTimeoutMessageHandlerSuccessfullyGenerateTCandSyncInfoAfterReachingThreshold`** updated: previously relied on `[]byte{1..5}` placeholder signatures and the absence of TC-side verification, which the refactor now correctly enforces. Now uses real signatures from masternode keys.

## Types of changes

- [x] feat: A new feature
- [x] fix: A bug fix
- [x] refactor: A code change that neither fixes a bug nor adds a feature
- [x] test: Adding missing tests or correcting existing tests

## Impacted Components

- [x] Consensus

## Checklist

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [x] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A