### PR TITLE
fix(consensus/signingTX): quick fix to return old signingTX behavior

### DIFF
--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -84,9 +84,7 @@ func CreateTransactionSign(chainConfig *params.ChainConfig, pool *txpool.TxPool,
 			}
 		}
 
-		// Use the pool's pending nonce so imported-block signing does not reuse
-		// an already-pending nonce and trigger replacement-underpriced errors.
-		nonce := pool.PoolNonce(account.Address)
+		nonce := pool.Nonce(account.Address)
 		tx := CreateTxSign(block.Number(), block.Hash(), nonce, common.BlockSignersBinary)
 		txSigned, err := wallet.SignTx(account, tx, chainConfig.ChainID)
 		if err != nil {

--- a/contracts/utils_test.go
+++ b/contracts/utils_test.go
@@ -501,8 +501,7 @@ func (s *nonceGuardSubPool) SetSigner(f func(address common.Address) bool) {}
 
 func (s *nonceGuardSubPool) IsSigner(addr common.Address) bool { return false }
 
-// TestCreateTransactionSignUsesPoolNonce tests create transaction sign uses pool nonce.
-func TestCreateTransactionSignUsesPoolNonce(t *testing.T) {
+func TestCreateTransactionSignUsesStateNonce(t *testing.T) {
 	password := "test-pass"
 	ks := keystore.NewKeyStore(t.TempDir(), keystore.LightScryptN, keystore.LightScryptP)
 
@@ -529,6 +528,17 @@ func TestCreateTransactionSignUsesPoolNonce(t *testing.T) {
 		t.Fatal("test requires XDPoS chain config")
 	}
 
+	// Set up a divergence between the two nonce sources so the test can tell which
+	// one CreateTransactionSign uses:
+	//   - chain STATE nonce = 0: createTxSignTestChain starts from an empty state,
+	//     so the account has never transacted (GetNonce == 0). pool.Nonce() reports
+	//     this.
+	//   - PENDING nonce = 1: a pool's pending nonce is "state nonce + number of
+	//     consecutive pending txs". nonceGuardSubPool.Nonce() is hard-coded to 1 to
+	//     model a pool that already holds one pending tx at nonce 0 (0 + 1 = 1).
+	//     pool.PoolNonce() (the max nonce across subpools) reports this.
+	// Seeding a real sign tx at nonce 0 keeps the subpool self-consistent: it both
+	// reports pending nonce 1 and, via Add, rejects a second tx at nonce 0.
 	seedTx := CreateTxSign(big.NewInt(0), common.Hash{0x1}, 0, common.BlockSignersBinary)
 	seedSigned, err := types.SignTx(seedTx, types.LatestSignerForChainID(chainConfig.ChainID), acc1Key)
 	if err != nil {
@@ -538,19 +548,24 @@ func TestCreateTransactionSignUsesPoolNonce(t *testing.T) {
 		t.Fatalf("failed to seed pending nonce 0 tx: %v", err)
 	}
 
+	// CreateTransactionSign must derive the nonce from chain STATE (0), not the
+	// pending nonce (1). Its sign tx therefore lands on the already-pending nonce 0
+	// and the pool rejects the duplicate with ErrReplaceUnderpriced. Had it used the
+	// pending nonce (1) there would be no collision and a second sign tx would be
+	// added at nonce 1 -- which the length check below rules out. The duplicate
+	// rejection is the expected outcome (whether surfaced or swallowed); any other
+	// error is a real failure.
 	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
-	err = CreateTransactionSign(chainConfig, pool, manager, block, rawdb.NewMemoryDatabase(), account.Address)
-	if errors.Is(err, txpool.ErrReplaceUnderpriced) {
-		t.Fatalf("CreateTransactionSign reused pending nonce and hit replacement rejection: %v", err)
-	}
-	if err != nil {
-		t.Fatalf("CreateTransactionSign failed: %v", err)
+	if err := CreateTransactionSign(chainConfig, pool, manager, block, rawdb.NewMemoryDatabase(), account.Address); err != nil && !errors.Is(err, txpool.ErrReplaceUnderpriced) {
+		t.Fatalf("unexpected error from CreateTransactionSign: %v", err)
 	}
 
-	if len(subpool.added) < 2 {
-		t.Fatalf("expected seed tx and tx sign to be added, got %d txs", len(subpool.added))
+	// Only the seeded tx is present: the colliding sign tx at state nonce 0 was
+	// rejected. A second entry (at nonce 1) would mean the pending nonce was used.
+	if len(subpool.added) != 1 {
+		t.Fatalf("expected only the seeded tx (sign tx should collide at state nonce 0), got %d txs", len(subpool.added))
 	}
-	if got := subpool.added[1].Nonce(); got != 1 {
-		t.Fatalf("tx sign nonce mismatch: got %d, want 1", got)
+	if got := subpool.added[0].Nonce(); got != 0 {
+		t.Fatalf("seeded tx nonce mismatch: got %d, want 0", got)
 	}
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1153,7 +1153,7 @@ func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Addr
 				continue
 			}
 			blkNumber := new(big.Int).SetBytes(data[4:36]).Uint64()
-			if blkNumber >= w.header.Number.Uint64() || blkNumber+w.config.XDPoS.Epoch*2 <= w.header.Number.Uint64() {
+			if blkNumber >= w.header.Number.Uint64() {
 				log.Trace("Data special transaction invalid number", "hash", hash, "blkNumber", blkNumber, "miner", w.header.Number)
 				continue
 			}


### PR DESCRIPTION
# Proposed changes

ref: https://github.com/XinFinOrg/XDPoSChain/issues/2358

return old signingTX behavior (same as previous release v2.7.0)

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transaction nonce selection during signing to use the chain state nonce
  * Broadened acceptance rules for special block-related transactions to include more historical blocks

* **Tests**
  * Updated and renamed tests to reflect the change in nonce behavior and expected outcomes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->